### PR TITLE
0: fix to disable warnings with rust 1.75

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Luwen
 
-Named after Antonie van Leeuwenhoek who invested the microsope.
+Named after Antonie van Leeuwenhoek who invented the microsope.
 
 ## Official Repository
 

--- a/crates/kmdif/src/ioctl.rs
+++ b/crates/kmdif/src/ioctl.rs
@@ -1,9 +1,9 @@
 // SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-const TENSTORRENT_IOCTL_MAGIC: usize = 0xFA;
-
 use nix::request_code_none;
+
+const TENSTORRENT_IOCTL_MAGIC: usize = 0xFA;
 
 #[derive(Default)]
 #[repr(C)]

--- a/crates/kmdif/src/lib.rs
+++ b/crates/kmdif/src/lib.rs
@@ -9,18 +9,18 @@ use std::{
     sync::Arc,
 };
 
+pub use error::{PciError, PciOpenError};
+use ioctl::{
+    AllocateDmaBuffer, GetDeviceInfo, GetDeviceInfoOut, Mapping, query_mappings, QueryMappings,
+};
+use luwen_core::Arch;
+pub use tlb::{DeviceTlbInfo, Tlb};
+
 mod error;
 mod ioctl;
 mod kmdif;
 mod pci;
 pub mod tlb;
-
-pub use error::{PciError, PciOpenError};
-use ioctl::{
-    query_mappings, AllocateDmaBuffer, GetDeviceInfo, GetDeviceInfoOut, Mapping, QueryMappings,
-};
-use luwen_core::Arch;
-pub use tlb::{DeviceTlbInfo, Tlb};
 
 impl From<&GetDeviceInfoOut> for Arch {
     fn from(value: &GetDeviceInfoOut) -> Self {

--- a/crates/kmdif/src/tlb/grayskull.rs
+++ b/crates/kmdif/src/tlb/grayskull.rs
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    tlb::{MemoryType, TlbInfo},
-    DeviceTlbInfo, PciDevice, PciError, Tlb,
+    DeviceTlbInfo,
+    PciDevice, PciError, tlb::{MemoryType, TlbInfo}, Tlb,
 };
 
 use super::Ordering;

--- a/crates/kmdif/src/tlb/wormhole.rs
+++ b/crates/kmdif/src/tlb/wormhole.rs
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    tlb::{MemoryType, TlbInfo},
-    DeviceTlbInfo, PciDevice, PciError, Tlb,
+    DeviceTlbInfo,
+    PciDevice, PciError, tlb::{MemoryType, TlbInfo}, Tlb,
 };
 
 use super::Ordering;

--- a/crates/luwen-if/src/chip/creation.rs
+++ b/crates/luwen-if/src/chip/creation.rs
@@ -7,12 +7,12 @@ use luwen_core::Arch;
 
 use crate::{
     arc_msg::ArcMsgAddr,
-    error::{BtWrapper, PlatformError},
     CallbackStorage,
+    error::{BtWrapper, PlatformError},
 };
 
 use super::{
-    communication::chip_comms::load_axi_table, ArcIf, Chip, ChipComms, ChipInterface, Grayskull,
+    ArcIf, Chip, ChipComms, ChipInterface, communication::chip_comms::load_axi_table, Grayskull,
     Wormhole,
 };
 

--- a/crates/luwen-if/src/chip/grayskull.rs
+++ b/crates/luwen-if/src/chip/grayskull.rs
@@ -7,9 +7,9 @@ use luwen_core::Arch;
 
 use crate::{
     arc_msg::{ArcMsgAddr, ArcMsgOk, ArcMsgProtocolError},
+    ArcMsg,
     chip::HlCommsInterface,
-    error::PlatformError,
-    ArcMsg, ChipImpl,
+    ChipImpl, error::PlatformError,
 };
 
 use super::{
@@ -25,6 +25,7 @@ pub struct Grayskull {
     pub arc_addrs: ArcMsgAddr,
 }
 
+#[allow(dead_code)]
 pub enum ArcReady {
     Ready,
     NotReady(ArcMsgProtocolError),
@@ -154,7 +155,7 @@ impl ChipImpl for Grayskull {
         {
             let status = &mut status.arc_status;
             match status.wait_status {
-                WaitStatus::Waiting(start) => {
+                WaitStatus::Waiting(_start) => {
                     let timeout = std::time::Duration::from_secs(10);
                     match self.check_arg_msg_safe(5, 3) {
                         Ok(_) => status.wait_status = WaitStatus::JustFinished,
@@ -164,7 +165,7 @@ impl ChipImpl for Grayskull {
                             }
 
                             // The fact that this is here means that our result is too generic, for now we just ignore it.
-                            PlatformError::ArcMsgError(err) => {
+                            PlatformError::ArcMsgError(_err) => {
                                 return Ok(ChipInitResult::ErrorContinue);
                             }
 

--- a/crates/luwen-if/src/chip/init.rs
+++ b/crates/luwen-if/src/chip/init.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{error::PlatformError, ChipImpl};
+use crate::{ChipImpl, error::PlatformError};
 
 use super::{InitStatus, StatusInfo};
 
@@ -17,6 +17,7 @@ pub struct ChipDetectState<'a> {
     pub call: CallReason<'a>,
 }
 
+#[allow(dead_code)]
 pub enum EthernetInitState {
     NotPresent,
     FwCorrupted,
@@ -24,6 +25,7 @@ pub enum EthernetInitState {
     Ready,
 }
 
+#[allow(dead_code)]
 pub enum ArcInitState {
     FwCorrupted,
     WaitingForInit,
@@ -31,6 +33,7 @@ pub enum ArcInitState {
     Ready,
 }
 
+#[allow(dead_code)]
 pub struct ChipInitState {
     pub can_access: bool,
     pub ethernet_state: EthernetInitState,
@@ -39,6 +42,7 @@ pub struct ChipInitState {
     underlying_chip: super::Chip,
 }
 
+#[allow(dead_code)]
 impl ChipInitState {
     pub fn get_chip(self) -> super::Chip {
         self.underlying_chip

--- a/crates/luwen-if/src/chip/mod.rs
+++ b/crates/luwen-if/src/chip/mod.rs
@@ -1,6 +1,19 @@
 // SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+pub use communication::chip_comms::{
+    ArcIf, axi_translate, AxiData, AxiError, ChipComms, MemorySlice, MemorySlices,
+};
+pub use communication::chip_interface::ChipInterface;
+pub use grayskull::Grayskull;
+pub use hl_comms::{HlComms, HlCommsInterface};
+pub use init::{CallReason, ChipDetectState, wait_for_init};
+use luwen_core::Arch;
+pub use wormhole::Wormhole;
+
+use crate::{arc_msg::ArcMsgAddr, DeviceInfo, error::PlatformError};
+pub use crate::arc_msg::{ArcMsg, ArcMsgOk};
+
 mod communication;
 mod creation;
 pub mod eth_addr;
@@ -9,20 +22,6 @@ mod hl_comms;
 mod init;
 mod remote;
 mod wormhole;
-
-pub use communication::chip_comms::{
-    axi_translate, ArcIf, AxiData, AxiError, ChipComms, MemorySlice, MemorySlices,
-};
-pub use communication::chip_interface::ChipInterface;
-pub use grayskull::Grayskull;
-pub use hl_comms::{HlComms, HlCommsInterface};
-pub use init::{wait_for_init, CallReason, ChipDetectState};
-use luwen_core::Arch;
-pub use wormhole::Wormhole;
-
-use crate::{arc_msg::ArcMsgAddr, error::PlatformError, DeviceInfo};
-
-pub use crate::arc_msg::{ArcMsg, ArcMsgOk};
 
 /// Arc message interface
 #[derive(Debug)]

--- a/crates/luwen-if/src/chip/remote.rs
+++ b/crates/luwen-if/src/chip/remote.rs
@@ -1,7 +1,6 @@
 // SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use super::{eth_addr::EthAddr, HlComms, MemorySlices, Wormhole};
 use crate::{
     chip::communication::{
         chip_comms::{axi_translate, AxiData, AxiError, ChipComms},
@@ -9,6 +8,8 @@ use crate::{
     },
     error::PlatformError,
 };
+
+use super::{eth_addr::EthAddr, HlComms, MemorySlices, Wormhole};
 
 pub struct RemoteArcIf {
     pub addr: EthAddr,

--- a/crates/luwen-if/src/chip/wormhole.rs
+++ b/crates/luwen-if/src/chip/wormhole.rs
@@ -4,23 +4,23 @@
 use std::sync::Arc;
 
 use crate::{
-    arc_msg::{ArcMsgAddr, ArcMsgOk, ArcMsgProtocolError},
+    arc_msg::{ArcMsgAddr, ArcMsgOk},
+    ArcMsg,
     chip::{
         communication::{
-            chip_comms::{load_axi_table, ChipComms},
+            chip_comms::{ChipComms, load_axi_table},
             chip_interface::ChipInterface,
         },
         hl_comms::HlCommsInterface,
     },
-    error::PlatformError,
-    ArcMsg, ChipImpl, IntoChip,
+    ChipImpl, error::PlatformError, IntoChip,
 };
 
 use super::{
+    ArcMsgOptions,
+    ChipInitResult,
     eth_addr::EthAddr,
-    hl_comms::HlComms,
-    remote::{EthAddresses, RemoteArcIf},
-    ArcMsgOptions, ChipInitResult, InitStatus, NeighbouringChip, StatusInfo, WaitStatus,
+    hl_comms::HlComms, InitStatus, NeighbouringChip, remote::{EthAddresses, RemoteArcIf}, StatusInfo, WaitStatus,
 };
 
 /// Implementation of the interface for a Wormhole
@@ -248,11 +248,11 @@ impl ChipImpl for Wormhole {
 
                             // If we hit these, something has gone terribly wrong. We will therefore abort...
                             PlatformError::WrongChipArch {
-                                actual,
-                                expected,
-                                backtrace,
+                                actual: _,
+                                expected: _,
+                                backtrace: _,
                             } => todo!(),
-                            PlatformError::UnsupportedFwVersion { version, required } => todo!(),
+                            PlatformError::UnsupportedFwVersion { version: _, required: _ } => todo!(),
                             PlatformError::ArcMsgError(_) => todo!(),
                             PlatformError::EthernetTrainingNotComplete(_) => todo!(),
                             PlatformError::Generic(_, _) => todo!(),
@@ -270,7 +270,7 @@ impl ChipImpl for Wormhole {
 
         {
             // TODO(drosen): Explicitly check against the telemetry info
-            let status = &mut status.dram_status;
+            let _status = &mut status.dram_status;
             // match status.wait_status {
             //     WaitStatus::Waiting(start) => {
             //         let timeout = std::time::Duration::from_secs(10);

--- a/crates/luwen-if/src/detect_chips.rs
+++ b/crates/luwen-if/src/detect_chips.rs
@@ -4,9 +4,9 @@
 use std::collections::HashSet;
 
 use crate::{
-    chip::{wait_for_init, Chip},
-    error::PlatformError,
-    ChipImpl, EthAddr,
+    chip::{Chip, wait_for_init},
+    ChipImpl,
+    error::PlatformError, EthAddr,
 };
 
 #[derive(PartialEq, Eq, Hash, Debug, Clone)]
@@ -40,7 +40,10 @@ pub fn detect_chips(
         // If cont is false, then we cannot continue to interact with the chip
         // if it's true, then we can continue.
         let cont = wait_for_init(root_chip, init_callback, continue_on_failure)?;
-
+        if !cont  {
+           print!("Cannot initialize chip {} ... continuing to next.",root_index);
+           continue
+        }
         let ident = if let Some(wh) = root_chip.as_wh() {
             let telem = root_chip.get_telemetry()?;
             remotes_to_investigate.push(root_index);

--- a/crates/luwen-if/src/error.rs
+++ b/crates/luwen-if/src/error.rs
@@ -3,8 +3,9 @@
 
 use std::fmt::Display;
 
-use luwen_core::Arch;
 use thiserror::Error;
+
+use luwen_core::Arch;
 
 use crate::arc_msg::ArcMsgError;
 

--- a/crates/luwen-if/src/interface.rs
+++ b/crates/luwen-if/src/interface.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::chip::{eth_addr::EthAddr, ChipInterface};
+use crate::chip::{ChipInterface, eth_addr::EthAddr};
 
 #[derive(Debug)]
 pub enum FnNoc {

--- a/crates/luwen-if/src/lib.rs
+++ b/crates/luwen-if/src/lib.rs
@@ -1,18 +1,21 @@
 // SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
 // SPDX-License-Identifier: Apache-2.0
+#![crate_type = "lib"]
+
+pub use arc_msg::{ArcMsg, ArcMsgError, ArcMsgOk, ArcMsgProtocolError};
+pub use chip::ChipImpl;
+pub use chip::eth_addr::{EthAddr, IntoChip};
+pub use detect_chips::{detect_chips, detect_chips_silent};
+pub use interface::{CallbackStorage, DeviceInfo, FnAxi, FnDriver, FnNoc, FnOptions, FnRemote};
 
 /// Luwen-if implements all high level functions in a backend agnostic way.
 /// In the simplest terms this includes everything defined in `ChipImpl`, `HlComms` and `detect_chips`.
 /// But this also includes chip specific functions which can be found in `Wormhole` and `Grayskull` chips.
 ///
+
 mod arc_msg;
 pub mod chip;
 mod detect_chips;
 pub mod error;
 mod interface;
 
-pub use arc_msg::{ArcMsg, ArcMsgError, ArcMsgOk, ArcMsgProtocolError};
-pub use chip::eth_addr::{EthAddr, IntoChip};
-pub use chip::ChipImpl;
-pub use detect_chips::{detect_chips, detect_chips_silent};
-pub use interface::{CallbackStorage, DeviceInfo, FnAxi, FnDriver, FnNoc, FnOptions, FnRemote};

--- a/crates/luwen-ref/src/detect.rs
+++ b/crates/luwen-ref/src/detect.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use kmdif::PciDevice;
-use luwen_if::{chip::Chip, CallbackStorage};
+use luwen_if::{CallbackStorage, chip::Chip};
 
 use crate::{comms_callback, error::LuwenError, ExtendedPciDevice};
 

--- a/crates/luwen-ref/src/error.rs
+++ b/crates/luwen-ref/src/error.rs
@@ -1,9 +1,10 @@
 // SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use kmdif::{PciError, PciOpenError};
-use luwen_if::{chip::AxiError, error::PlatformError, ArcMsgError};
 use thiserror::Error;
+
+use kmdif::{PciError, PciOpenError};
+use luwen_if::{ArcMsgError, chip::AxiError, error::PlatformError};
 
 #[derive(Error, Debug)]
 pub enum LuwenError {

--- a/crates/luwen-ref/src/lib.rs
+++ b/crates/luwen-ref/src/lib.rs
@@ -6,18 +6,16 @@ use std::{
     sync::{Arc, RwLock, RwLockReadGuard, RwLockWriteGuard},
 };
 
+pub use detect::detect_chips;
 use error::LuwenError;
+pub use kmdif::{DmaBuffer, DmaConfig, PciDevice, Tlb};
 use kmdif::PciError;
 use luwen_if::{FnDriver, FnOptions};
+use wormhole::ethernet::{self, EthCommCoord};
 
 mod detect;
 pub mod error;
 mod wormhole;
-
-use wormhole::ethernet::{self, EthCommCoord};
-
-pub use detect::detect_chips;
-pub use kmdif::{DmaBuffer, DmaConfig, PciDevice, Tlb};
 
 #[derive(Clone)]
 pub struct ExtendedPciDeviceWrapper {

--- a/crates/luwen-ref/src/wormhole/ethernet/mod.rs
+++ b/crates/luwen-ref/src/wormhole/ethernet/mod.rs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+pub use ethernet_6::*;
+
 mod ethernet_6;
 
-pub use ethernet_6::*;

--- a/crates/luwencpp/src/lib.rs
+++ b/crates/luwencpp/src/lib.rs
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use luwen_if::{
-    chip::{ArcMsgOptions, Chip},
-    error::PlatformError,
-    ArcMsg, ArcMsgError, ArcMsgProtocolError, CallbackStorage, ChipImpl, FnOptions,
+    ArcMsg,
+    ArcMsgError,
+    ArcMsgProtocolError, CallbackStorage, chip::{ArcMsgOptions, Chip}, ChipImpl, error::PlatformError, FnOptions,
 };
 
 #[repr(C)]

--- a/crates/pyluwen/src/lib.rs
+++ b/crates/pyluwen/src/lib.rs
@@ -3,13 +3,14 @@
 
 use std::ops::{Deref, DerefMut};
 
-use luwen_if::chip::{
-    wait_for_init, ArcMsg, ArcMsgOk, ArcMsgOptions, ChipImpl, HlComms, HlCommsInterface, StatusInfo,
-};
-use luwen_if::{CallbackStorage, DeviceInfo};
-use luwen_ref::{DmaConfig, ExtendedPciDeviceWrapper};
 use pyo3::exceptions::PyException;
 use pyo3::prelude::*;
+
+use luwen_if::{CallbackStorage, DeviceInfo};
+use luwen_if::chip::{
+    ArcMsg, ArcMsgOk, ArcMsgOptions, ChipImpl, HlComms, HlCommsInterface, wait_for_init,
+};
+use luwen_ref::{DmaConfig, ExtendedPciDeviceWrapper};
 
 #[pyclass]
 pub struct PciChip(luwen_if::chip::Chip);
@@ -457,7 +458,7 @@ impl PciChip {
     }
 
     pub fn init(&self) {
-        wait_for_init(&self.0, &mut |_| {}, false);
+        let _= wait_for_init(&self.0, &mut |_| {}, false);
     }
 
     pub fn board_id(&self) -> u64 {

--- a/src/bin/ethernet_benchmark.rs
+++ b/src/bin/ethernet_benchmark.rs
@@ -1,9 +1,10 @@
 // SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use luwen_if::{chip::HlComms, CallbackStorage, ChipImpl};
-use luwen_ref::error::LuwenError;
 use rand::Rng;
+
+use luwen_if::{CallbackStorage, chip::HlComms, ChipImpl};
+use luwen_ref::error::LuwenError;
 
 fn read_write_test(
     chip: impl HlComms,

--- a/src/bin/generate_names.rs
+++ b/src/bin/generate_names.rs
@@ -3,11 +3,12 @@
 
 use std::collections::HashMap;
 
-use luwen_if::chip::{axi_translate, MemorySlice, MemorySlices};
 use serde::{
     de::{value::SeqAccessDeserializer, Visitor},
     Deserialize, Deserializer, Serialize,
 };
+
+use luwen_if::chip::{axi_translate, MemorySlice, MemorySlices};
 
 #[derive(Debug, Serialize)]
 pub enum Fields {

--- a/src/bin/luwen-demo.rs
+++ b/src/bin/luwen-demo.rs
@@ -1,12 +1,13 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2023-24 Tenstorrent Inc.
 // SPDX-License-Identifier: Apache-2.0
+#![allow(unused_imports)]
 
 use luwen_if::{
-    chip::{ArcMsgOptions, Chip, HlComms, HlCommsInterface},
-    detect_chips, ArcMsg, CallbackStorage, ChipImpl,
+    ArcMsg
+    , CallbackStorage, chip::{ArcMsgOptions, Chip, HlComms, HlCommsInterface}, ChipImpl,
 };
 use luwen_ref::{
-    comms_callback, error::LuwenError, DmaConfig, ExtendedPciDevice, ExtendedPciDeviceWrapper,
+    comms_callback, DmaConfig, error::LuwenError, ExtendedPciDevice, ExtendedPciDeviceWrapper,
     PciDevice, Tlb,
 };
 
@@ -21,7 +22,7 @@ pub fn main() -> Result<(), LuwenError> {
         let chip = Chip::open(arch, CallbackStorage::new(comms_callback, ud));
 
         if let Some(wh) = chip.as_wh() {
-            let mut hi = wh
+            let hi = wh
                 .chip_if
                 .as_any()
                 .downcast_ref::<CallbackStorage<ExtendedPciDeviceWrapper>>()
@@ -44,7 +45,7 @@ pub fn main() -> Result<(), LuwenError> {
                     write_threshold: 0,
                 });
 
-                let (offset, size) = pci_interface.setup_tlb(
+                let (offset, _size) = pci_interface.setup_tlb(
                     168,
                     Tlb {
                         local_offset: 0x0,


### PR DESCRIPTION
0: fix to disable warnings and minor typo for rust 1.75