### PR TITLE
Install maturin as part of pyenv since it's needed to build

### DIFF
--- a/crates/pyluwen/Makefile
+++ b/crates/pyluwen/Makefile
@@ -3,6 +3,7 @@ PYTHON?=python3
 .py03-env:
 	$(PYTHON) -m venv .py03-env
 	. .py03-env/bin/activate && pip install --upgrade pip
+	. .py03-env/bin/activate && pip install maturin
 	. .py03-env/bin/activate && pip install -ve .
 
 .PHONY: whl


### PR DESCRIPTION
Maturin isn't tracked as a dependency anywhere, but it's needed to build. Luckily we can just pip install it when we setup the pyenv in the first place.