### PR TITLE
Add version field to pyproject.toml for pyluwen (v0.4.8)

### DIFF
--- a/crates/pyluwen/pyproject.toml
+++ b/crates/pyluwen/pyproject.toml
@@ -7,6 +7,7 @@ build-backend = "maturin"
 [project]
 name = "pyluwen"
 requires-python = ">=3.7"
+version = "0.4.8"
 classifiers = [
 	"Programming Language :: Rust",
 	"Programming Language :: Python :: Implementation :: CPython",


### PR DESCRIPTION
## Changes
- Added `version = "0.4.8"` to `crates/pyluwen/pyproject.toml`.

## Why this is needed
- This change resolves build failures occurring during the installation of `pyluwen` via pip.
- **This issue also affects the installation of the `tt-smi` package**, as `pyluwen` is a dependency.


### Installation Failure Log (Before Adding Version)
```rust
pip install ./crates/pyluwen
Processing ./crates/pyluwen
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
  Preparing metadata (pyproject.toml) ... error
  error: subprocess-exited-with-error

  × Preparing metadata (pyproject.toml) did not run successfully.
  │ exit code: 1
  ╰─> [5 lines of output]
      💥 maturin failed
        Caused by: `project.version` field is required in pyproject.toml unless it is present in the `project.dynamic` list
      Error running maturin: Command '['maturin', 'pep517', 'write-dist-info', '--metadata-directory', '/tmp/pip-modern-metadata-7v6sai1t', '--interpreter', '/home/dongjin/anaconda3/bin/python']' returned non-zero exit status 1.
      Checking for Rust toolchain....
      Running `maturin pep517 write-dist-info --metadata-directory /tmp/pip-modern-metadata-7v6sai1t --interpreter /home/dongjin/anaconda3/bin/python`
      [end of output]

  note: This error originates from a subprocess, and is likely not a problem with pip.
error: metadata-generation-failed

× Encountered error while generating package metadata.
╰─> See above for output.

note: This is an issue with the package mentioned above, not pip.
hint: See above for details.
```

### After adding version in `crates/pyluwen/pyproject.toml`.
```rust
 pip install ./crates/pyluwen
Processing ./crates/pyluwen
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
  Preparing metadata (pyproject.toml) ... done
Building wheels for collected packages: pyluwen
  Building wheel for pyluwen (pyproject.toml) ... done
  Created wheel for pyluwen: filename=pyluwen-0.4.8-cp312-cp312-linux_x86_64.whl size=616338 sha256=064eb4d1355f76df2520b5f27a270a9dcf75b9e7a2d401a521d7ce798e236b3d
  Stored in directory: /tmp/pip-ephem-wheel-cache-gt9sgh38/wheels/19/55/1c/9c3984010e91ebb2f6adb1c87d9ba112a1172c13d4c5426861
Successfully built pyluwen
Installing collected packages: pyluwen
  Attempting uninstall: pyluwen
    Found existing installation: pyluwen 0.4.8
    Uninstalling pyluwen-0.4.8:
      Successfully uninstalled pyluwen-0.4.8
Successfully installed pyluwen-0.4.8
```