### PR TITLE
Pyluwen: Add "version" to pyproject.toml

### DIFF
--- a/crates/pyluwen/pyproject.toml
+++ b/crates/pyluwen/pyproject.toml
@@ -7,6 +7,9 @@ build-backend = "maturin"
 [project]
 name = "pyluwen"
 requires-python = ">=3.7"
+
+dynamic = ["version"]
+
 classifiers = [
 	"Programming Language :: Rust",
 	"Programming Language :: Python :: Implementation :: CPython",


### PR DESCRIPTION
Maturin made a change to come inline more specifically with pyproject.toml spec, unfortunately it's not a "backwards compatible" change and was done with little fanfare or warning, and immediately caused breakage outside distro's more plodding versions.

Maturin Issue: https://github.com/PyO3/maturin/issues/2390
pyproject.toml spec: https://packaging.python.org/en/latest/specifications/pyproject-toml/#dynamic

change in Maturin committed here:

https://github.com/PyO3/maturin/pull/2391

This commit superceeds the luwen PR here:

https://github.com/tenstorrent/luwen/pull/11

as that sets an explicit version, and we don't want that as it adds more sources of truth on the version (seriously there should be 1, and only 1).