### PR TITLE
If the telemetry struct failed to init then it will be 0

### DIFF
--- a/crates/luwen-if/src/chip/blackhole.rs
+++ b/crates/luwen-if/src/chip/blackhole.rs
@@ -518,6 +518,13 @@ impl ChipImpl for Blackhole {
         self.axi_read_field(&self.telemetry_struct_addr, &mut scratch_reg_13_value)?;
         let telem_struct_addr = u32::from_le_bytes(scratch_reg_13_value);
 
+        if telem_struct_addr == 0 {
+            return Err(PlatformError::ArcNotReady(
+                crate::error::ArcReadyError::BootIncomplete,
+                BtWrapper::capture(),
+            ));
+        }
+
         // Read the data block from the address in sctrach 13
         // Parse out the version and entry count before reading the data block
         let _version = self.axi_read32(telem_struct_addr as u64)?;


### PR DESCRIPTION
Previously just checked that the boot complete struct marked msgqueue init as complete. This is not sufficient, now check that the telemetry struct is at a valid (non-zero) address before attempting to read the telemetry data.