### PR TITLE
Fix of telemetry funtest range checks + a handful of clippy cleanups

### DIFF
--- a/crates/luwen-if/src/chip/spi.rs
+++ b/crates/luwen-if/src/chip/spi.rs
@@ -219,12 +219,10 @@ impl Spi {
         // Write sector lock info
         if simple_spi {
             chip.axi_write32(self.spi_dr, (1 << 6) | (sections as u32) << 2)?;
+        } else if sections < 5 {
+            chip.axi_write32(self.spi_dr, 0x3 << 5 | (sections as u32) << 2)?;
         } else {
-            if sections < 5 {
-                chip.axi_write32(self.spi_dr, 0x3 << 5 | (sections as u32) << 2)?;
-            } else {
-                chip.axi_write32(self.spi_dr, 0x1 << 5 | (sections as u32 - 5) << 2)?;
-            }
+            chip.axi_write32(self.spi_dr, 0x1 << 5 | (sections as u32 - 5) << 2)?;
         }
         chip.axi_write32(self.spi_ser, spi_ser_slave_enable(0))?;
 

--- a/crates/ttkmd-if/src/pci.rs
+++ b/crates/ttkmd-if/src/pci.rs
@@ -493,9 +493,7 @@ impl PciDevice {
                 let read_count = (core::mem::size_of::<u32>() - byte_offset).min(bytes_left);
 
                 let read = read.to_le_bytes();
-                for i in 0..read_count {
-                    dest[offset + i] = read[i];
-                }
+                dest[offset..(read_count + offset)].copy_from_slice(&read[..read_count]);
 
                 offset += read_count
             } else {

--- a/crates/ttkmd-if/src/tlb/blackhole.rs
+++ b/crates/ttkmd-if/src/tlb/blackhole.rs
@@ -79,7 +79,7 @@ impl From<Tlb> for (Tlb2M, Tlb2MStride) {
 impl From<(Tlb2M, Option<Tlb2MStride>)> for Tlb {
     fn from(value: (Tlb2M, Option<Tlb2MStride>)) -> Self {
         Tlb {
-            local_offset: value.0.local_offset() as u64,
+            local_offset: value.0.local_offset(),
             x_end: value.0.x_end(),
             y_end: value.0.y_end(),
             x_start: value.0.x_start(),
@@ -108,7 +108,7 @@ impl From<(Tlb2M, Option<Tlb2MStride>)> for Tlb {
 impl From<Tlb2M> for Tlb {
     fn from(value: Tlb2M) -> Self {
         Tlb {
-            local_offset: value.local_offset() as u64,
+            local_offset: value.local_offset(),
             x_end: value.x_end(),
             y_end: value.y_end(),
             x_start: value.x_start(),

--- a/src/bin/detect_test.rs
+++ b/src/bin/detect_test.rs
@@ -26,7 +26,7 @@ fn main() {
                 if let Some(gs) = v.as_gs() {
                     println!(
                         "{:x}",
-                        gs.axi_sread32(format!("ARC_RESET.SCRATCH[0]")).unwrap()
+                        gs.axi_sread32("ARC_RESET.SCRATCH[0]").unwrap()
                     );
                 }
 
@@ -48,7 +48,7 @@ fn main() {
 
                     println!(
                         "{:x}",
-                        bh.axi_sread32(format!("arc_ss.reset_unit.SCRATCH_RAM[0]"))
+                        bh.axi_sread32("arc_ss.reset_unit.SCRATCH_RAM[0]")
                             .unwrap()
                     );
 

--- a/src/bin/generate_names.rs
+++ b/src/bin/generate_names.rs
@@ -226,7 +226,7 @@ fn parse_yaml_translation_file(
     for (name, top) in top_level.tops {
         println!("Parsing {name}");
         let defs: MemoryDefs =
-            serde_yaml::from_slice(&std::fs::read(&format!("{path}/{}", top.filename))?)?;
+            serde_yaml::from_slice(&std::fs::read(format!("{path}/{}", top.filename))?)?;
 
         let value = slices.entry(name.clone()).or_insert_with(|| MemorySlice {
             name,

--- a/src/bin/read-write-test.rs
+++ b/src/bin/read-write-test.rs
@@ -99,9 +99,7 @@ fn main() {
                 .unwrap();
             assert_eq!(write_buffer, readback_buffer);
 
-            let mut write_buffer = Vec::new();
-            write_buffer.push(0xad);
-            write_buffer.push(0xde);
+            let write_buffer = vec![0xad, 0xde];
             raw_device
                 .write_block(aligned_addr as u32 + 1, &write_buffer)
                 .unwrap();
@@ -125,9 +123,7 @@ fn main() {
                 .unwrap();
             assert_eq!(write_buffer, readback_buffer);
 
-            let mut write_buffer = Vec::new();
-            write_buffer.push(0xad);
-            write_buffer.push(0xde);
+            let write_buffer = vec![0xad, 0xde];
             raw_device
                 .write_block(aligned_addr as u32 + 3, &write_buffer)
                 .unwrap();

--- a/src/bin/telem_funtest.rs
+++ b/src/bin/telem_funtest.rs
@@ -29,7 +29,7 @@ fn main() {
         );
     }
 
-    if telem_a.tdc < 3 && telem_a.tdc > 200 {
+    if telem_a.tdc < 3 || telem_a.tdc > 200 {
         panic!(
             "\x1b[0;31m[FAIL]\x1b[0m Board tdc reading is outside of the expected range {}",
             telem_a.tdc

--- a/src/bin/telem_test.rs
+++ b/src/bin/telem_test.rs
@@ -26,7 +26,7 @@ fn main() {
                 if let Some(gs) = v.as_gs() {
                     println!(
                         "{:x}",
-                        gs.axi_sread32(format!("ARC_RESET.SCRATCH[0]")).unwrap()
+                        gs.axi_sread32("ARC_RESET.SCRATCH[0]").unwrap()
                     );
                 }
 
@@ -36,11 +36,10 @@ fn main() {
 
                     let subsystem = bh.get_if::<luwen_if::chip::NocInterface>()
                         .map(|v| &v.backing)
-                        .map(|v| {
+                        .and_then(|v| {
                             v.as_any()
                                 .downcast_ref::<luwen_if::CallbackStorage<luwen_ref::ExtendedPciDeviceWrapper>>()
                         })
-                        .flatten()
                         .map(|v| v.user_data.borrow().device.physical.subsystem_id)
                         .unwrap();
                     dbg!(subsystem);


### PR DESCRIPTION
Fixes an invalid check in telemetry funtest.

The rest is mostly cleanups from cargo clippy warnings/suggestions.