### PR TITLE
Added a new application to report harvesting status

### DIFF
--- a/app/check_harvesting/Cargo.toml
+++ b/app/check_harvesting/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "check_harvesting"
+version = "0.1.1"
+edition = "2021"
+
+[dependencies]
+ttkmd-if = {path = "../../crates/ttkmd-if", version = "0.2.1" }
+luwen-core = {path = "../../crates/luwen-core", version = "0.2.0"}
+luwen-if = {path = "../../crates/luwen-if", version = "0.6.0"}
+luwen-ref = {path = "../../crates/luwen-ref", version = "0.5.1" }
+clap = { version = "4.4.6", features = ["derive"] }
+prometheus_exporter = "0.8.5"
+prometheus = { version = "0.13.3", features = ["process"] }

--- a/app/check_harvesting/src/main.rs
+++ b/app/check_harvesting/src/main.rs
@@ -1,0 +1,54 @@
+use luwen_if::ChipImpl;
+
+fn main() {
+    let interfaces = luwen_ref::PciDevice::scan();
+    eprintln!("Found {} chips to check", interfaces.len());
+
+    let mut output = String::new();
+    output.push_str("{\n");
+    for interface in interfaces.iter().copied() {
+        // Just try to reset the link... if it fails then we should still try stuff
+        let chip = luwen_ref::open(interface);
+        let chip = match chip {
+            Ok(chip) => chip,
+            Err(err) => {
+                eprintln!("Error: Hit error {err:?} while trying to open {interface}");
+                continue;
+            }
+        };
+
+        let chip = match chip.as_bh() {
+            Some(chip) => chip,
+            None => {
+                eprintln!("Error: {interface} not BH it is {}", chip.get_arch());
+                continue;
+            }
+        };
+
+        let telem = match chip.get_telemetry() {
+            Ok(telem) => telem,
+            Err(err) => {
+                eprintln!("Error: failed to get telemetry from {interface} instead hit {err:?}");
+                continue;
+            }
+        };
+
+        output.push_str(&format!("\t\"{interface}\": {{\n"));
+        output.push_str(&format!(
+            "\t\t\"enabled tensix\": {},\n",
+            telem.tensix_enabled_col
+        ));
+        output.push_str(&format!("\t\t\"enabled eth\": {},\n", telem.enabled_eth));
+        output.push_str(&format!("\t\t\"enabled gddr\": {},\n", telem.enabled_gddr));
+        output.push_str(&format!(
+            "\t\t\"enabled l2cpu\": {},\n",
+            telem.enabled_l2cpu
+        ));
+        output.push_str(&format!("\t\t\"enabled pcie\": {}\n", telem.enabled_pcie));
+        output.push_str("\t}},\n");
+    }
+    output.pop();
+    output.pop();
+    output.push_str("\n}");
+    print!("{}", output);
+}


### PR DESCRIPTION
This tool prints to stdout (formated as json) the current harvesting state of all detectable chips. This allows developers to better understand the state of their boards without needing to run a larger piece of software.