### PR TITLE
Write create-ethernet-map output to yaml file

### DIFF
--- a/app/create-ethernet-map/Cargo.toml
+++ b/app/create-ethernet-map/Cargo.toml
@@ -13,3 +13,5 @@ luwen-ref = {path = "../../crates/luwen-ref", version = "0.5.1" }
 clap = { version = "4.4.6", features = ["derive"] }
 prometheus_exporter = "0.8.5"
 prometheus = { version = "0.13.3", features = ["process"] }
+serde = {version = "1.0.185", features = ["derive"]}
+serde_yaml = "0.9"

--- a/app/create-ethernet-map/src/lib.rs
+++ b/app/create-ethernet-map/src/lib.rs
@@ -10,7 +10,12 @@ use luwen_if::{
 };
 use luwen_ref::error::LuwenError;
 
-#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+use serde::{Deserialize, Serialize};
+use std::fs::File;
+use std::io::Write;
+use std::path::Path;
+
+#[derive(Debug, Clone, Hash, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ChipIdent {
     pub arch: Arch,
     pub board_id: Option<u64>,
@@ -18,14 +23,43 @@ pub struct ChipIdent {
     pub coord: Option<EthAddr>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ChipData {
     pub noc_translation_en: bool,
     pub harvest_mask: u32,
     pub boardtype: Option<String>,
 }
 
-pub fn generate_map(file: impl AsRef<str>) -> Result<(), LuwenError> {
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+pub struct EthernetLink {
+    pub chip: usize,
+    pub chan: usize,
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+pub struct EthernetConnection {
+    pub source: EthernetLink,
+    pub destination: EthernetLink,
+    pub routing_enabled: bool,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct EthernetMap {
+    pub arch: HashMap<usize, Arch>,
+    pub chips: HashMap<usize, EthAddr>,
+    pub ethernet_connections: Vec<EthernetConnection>,
+    pub chips_with_mmio: HashMap<usize, u32>,
+    pub harvesting: HashMap<usize, HarvestInfo>,
+    pub boardtype: HashMap<usize, Option<String>>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct HarvestInfo {
+    pub noc_translation: bool,
+    pub harvest_mask: u32,
+}
+
+pub fn generate_map() -> Result<EthernetMap, LuwenError> {
     let mut chips = HashMap::new();
     let mut chip_data = HashMap::new();
     let mut mmio_chips = Vec::new();
@@ -179,9 +213,32 @@ pub fn generate_map(file: impl AsRef<str>) -> Result<(), LuwenError> {
     ident_order.sort_by_key(|v| v.1);
     let ident_order: Vec<_> = ident_order.into_iter().map(|v| v.0.clone()).collect();
 
+    let mut arch_map = HashMap::new();
+    let mut chips_map = HashMap::new();
+    let mut chips_with_mmio_map = HashMap::new();
+    let mut harvesting_map = HashMap::new();
+    let mut boardtype_map = HashMap::new();
+
     let mut known_connections = HashSet::new();
     for chip in &ident_order {
         if let Some(connection_info) = connection_map.get(chip) {
+            let id = chips[chip];
+            arch_map.insert(id, chip.arch);
+
+            if let Some(coord) = &chip.coord {
+                chips_map.insert(id, *coord);
+            }
+
+            let data = &chip_data[chip];
+            harvesting_map.insert(
+                id,
+                HarvestInfo {
+                    noc_translation: data.noc_translation_en,
+                    harvest_mask: data.harvest_mask,
+                },
+            );
+
+            boardtype_map.insert(id, data.boardtype.clone());
             for (remote_chip, connection) in connection_info {
                 for (current_eth_id, next_eth_id, routing_enabled) in connection {
                     let local = (chips[chip], current_eth_id);
@@ -191,13 +248,22 @@ pub fn generate_map(file: impl AsRef<str>) -> Result<(), LuwenError> {
                     let second = local.max(remote);
 
                     let connection_ident = (first, second);
-                    let larger_connection_ident = (first, second, routing_enabled);
                     if known_connections.contains(&connection_ident) {
                         continue;
                     }
                     known_connections.insert(connection_ident);
 
-                    connections.push(larger_connection_ident);
+                    connections.push(EthernetConnection {
+                        source: EthernetLink {
+                            chip: first.0,
+                            chan: *first.1,
+                        },
+                        destination: EthernetLink {
+                            chip: second.0,
+                            chan: *second.1,
+                        },
+                        routing_enabled: *routing_enabled,
+                    });
                 }
             }
         }
@@ -205,74 +271,36 @@ pub fn generate_map(file: impl AsRef<str>) -> Result<(), LuwenError> {
 
     connections.sort();
 
-    let mut output = String::new();
-
-    output.push_str("arch: {\n");
-    for chip in &ident_order {
-        let id = chips[chip];
-        output.push_str(&format!("   {}: {:?},\n", id, chip.arch));
-    }
-    output.push_str("}\n\n");
-
-    output.push_str("chips: {\n");
-    for chip in &ident_order {
-        let id = chips[chip];
-        if let Some(coord) = &chip.coord {
-            output.push_str(&format!(
-                "   {}: [{},{},{},{}],\n",
-                id, coord.shelf_x, coord.shelf_y, coord.rack_x, coord.rack_y
-            ));
-        }
-    }
-    output.push_str("}\n\n");
-
-    output.push_str("ethernet_connections: [\n");
-    for ((local_chip, local_port), (remote_chip, remote_port), routing) in connections {
-        output.push_str(&format!("   [{{chip: {local_chip}, chan: {local_port}}}, {{chip: {remote_chip}, chan: {remote_port}}}, {{routing_enabled: {routing}}}],\n"));
-    }
-    output.push_str("]\n\n");
-
-    mmio_chips.sort_by_key(|v| v.1);
-
-    output.push_str("chips_with_mmio: [\n");
-    for (mmio, interface) in mmio_chips {
+    for (mmio, interface) in &mmio_chips {
         if let Some(interface) = interface {
-            output.push_str(&format!("   {}: {},\n", chips[&mmio], interface));
+            chips_with_mmio_map.insert(chips[mmio], *interface);
         }
     }
-    output.push_str("]\n\n");
 
-    output.push_str("# harvest_mask is the bit indicating which tensix row is harvested. So bit 0 = first tensix row; bit 1 = second tensix row etc...\n");
-    output.push_str("harvesting: {\n");
-    for chip in &ident_order {
-        let id = chips[chip];
-        let data = &chip_data[chip];
-        output.push_str(&format!(
-            "   {}: {{noc_translation: {}, harvest_mask: {}}},\n",
-            id, data.noc_translation_en, data.harvest_mask
-        ));
-    }
-    output.push_str("}\n\n");
+    // Create the map
+    let ethernet_map = EthernetMap {
+        arch: arch_map,
+        chips: chips_map,
+        ethernet_connections: connections,
+        chips_with_mmio: chips_with_mmio_map,
+        harvesting: harvesting_map,
+        boardtype: boardtype_map,
+    };
 
-    output.push_str("# This value will be null if the boardtype is unknown, should never happen in practice but to be defensive it would be useful to throw an error on this case.\n");
-    output.push_str("boardtype: {\n");
-    for chip in &ident_order {
-        let id = chips[chip];
-        let data = &chip_data[chip];
-        output.push_str(&format!(
-            "   {id}: {},\n",
-            data.boardtype.as_deref().unwrap_or("null")
-        ));
-    }
-    output.push('}');
+    Ok(ethernet_map)
+}
 
-    let file = file.as_ref();
+pub fn write_ethernet_map<W: Write>(writer: W, map: &EthernetMap) -> Result<(), LuwenError> {
+    serde_yaml::to_writer(writer, map)
+        .map_err(|e| LuwenError::Custom(format!("Failed to write YAML: {e}")))
+}
 
-    if let Err(_err) = std::fs::write(file, output) {
-        Err(LuwenError::Custom(format!("Failed to write to {}", file)))
-    } else {
-        Ok(())
-    }
+pub fn read_ethernet_map<P: AsRef<Path>>(path: P) -> Result<EthernetMap, LuwenError> {
+    let file =
+        File::open(path).map_err(|e| LuwenError::Custom(format!("Failed to open file: {e}")))?;
+
+    serde_yaml::from_reader(file)
+        .map_err(|e| LuwenError::Custom(format!("Failed to parse YAML: {e}")))
 }
 
 #[no_mangle]
@@ -289,10 +317,26 @@ pub unsafe extern "C" fn create_ethernet_map(file: *const std::ffi::c_char) -> s
     }
 
     let file = std::ffi::CStr::from_ptr(file);
-    if let Err(value) = generate_map(file.to_string_lossy()) {
-        eprintln!("Error while generating ethernet map!\n{value}");
-        -1
-    } else {
-        0
+    let filename = file.to_string_lossy();
+
+    match File::create(&*filename) {
+        Ok(file) => match generate_map() {
+            Ok(map) => {
+                if let Err(value) = write_ethernet_map(file, &map) {
+                    eprintln!("Error while writing ethernet map!\n{value}");
+                    -1
+                } else {
+                    0
+                }
+            }
+            Err(e) => {
+                eprintln!("Failed to run create ethernet map: {e}");
+                -1
+            }
+        },
+        Err(e) => {
+            eprintln!("Failed to create file: {e}");
+            -2
+        }
     }
 }

--- a/app/create-ethernet-map/src/main.rs
+++ b/app/create-ethernet-map/src/main.rs
@@ -1,12 +1,29 @@
 use clap::Parser;
+use std::fs::File;
+use std::io;
 
 #[derive(Parser)]
 pub struct CmdArgs {
-    file: String,
+    #[arg(short, long)]
+    output: Option<String>,
 }
 
 fn main() -> Result<(), luwen_ref::error::LuwenError> {
     let args = CmdArgs::parse();
 
-    create_ethernet_map::generate_map(args.file)
+    let map = create_ethernet_map::generate_map()?;
+    match &args.output.as_deref() {
+        Some("-") => {
+            let stdout = io::stdout();
+            let handle = stdout.lock();
+            create_ethernet_map::write_ethernet_map(handle, &map)
+        }
+        Some(filename) => {
+            let output_file = File::create(filename).map_err(|e| {
+                luwen_ref::error::LuwenError::Custom(format!("Failed to create file: {e}"))
+            })?;
+            create_ethernet_map::write_ethernet_map(output_file, &map)
+        }
+        None => Ok(()),
+    }
 }

--- a/crates/luwen-core/Cargo.toml
+++ b/crates/luwen-core/Cargo.toml
@@ -7,3 +7,4 @@ license = "Apache-2.0"
 
 [dependencies]
 thiserror = "1.0.40"
+serde = {version = "1.0.185", features = ["derive"]}

--- a/crates/luwen-core/src/lib.rs
+++ b/crates/luwen-core/src/lib.rs
@@ -1,10 +1,11 @@
 // SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use serde::{Deserialize, Serialize};
 use std::fmt;
 use std::str::FromStr;
 
-#[derive(Clone, Hash, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Hash, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum Arch {
     Grayskull,
     Wormhole,

--- a/crates/luwen-if/src/chip/eth_addr.rs
+++ b/crates/luwen-if/src/chip/eth_addr.rs
@@ -7,7 +7,9 @@ use crate::error::PlatformError;
 
 use super::{ChipComms, ChipInterface};
 
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, Serialize, Deserialize)]
 pub struct EthAddr {
     pub shelf_x: u8,
     pub shelf_y: u8,


### PR DESCRIPTION
This makes create-ethernet-map's output machine parse able, and useful for running checks on the links it outputs.

Running it with `--output -` will output to stdout. Running it with `--output filename` will write it to a file

This is the sample output from a node with 2x n300
```
arch:
  3: Wormhole
  2: Wormhole
  0: Wormhole
  1: Wormhole
chips:
  0:
    shelf_x: 0
    shelf_y: 0
    rack_x: 0
    rack_y: 0
  2:
    shelf_x: 1
    shelf_y: 0
    rack_x: 0
    rack_y: 0
  3:
    shelf_x: 1
    shelf_y: 0
    rack_x: 0
    rack_y: 0
  1:
    shelf_x: 0
    shelf_y: 0
    rack_x: 0
    rack_y: 0
ethernet_connections:
- source:
    chip: 0
    chan: 8
  destination:
    chip: 2
    chan: 0
- source:
    chip: 0
    chan: 9
  destination:
    chip: 2
    chan: 1
- source:
    chip: 1
    chan: 8
  destination:
    chip: 3
    chan: 0
- source:
    chip: 1
    chan: 9
  destination:
    chip: 3
    chan: 1
chips_with_mmio:
  0: 0
  1: 1
harvesting:
  3:
    noc_translation: true
    harvest_mask: 9
  2:
    noc_translation: true
    harvest_mask: 257
  1:
    noc_translation: true
    harvest_mask: 5
  0:
    noc_translation: true
    harvest_mask: 17
boardtype:
  3: n300
  2: n300
  0: n300
  1: n300
```

Output on bh
```
arch:
  0: Blackhole
chips: {}
ethernet_connections: []
chips_with_mmio:
  0: 0
harvesting:
  0:
    noc_translation: false
    harvest_mask: 0
boardtype:
  0: p100
```

While I do agree it becomes slightly less pleasing to look at to the eye, it's machine readable-ness outweighs that con