### PR TITLE
Added support for allocating the tlb from the driver (if supported)

### DIFF
--- a/crates/luwen-if/src/interface.rs
+++ b/crates/luwen-if/src/interface.rs
@@ -72,7 +72,7 @@ pub struct DeviceInfo {
     pub vendor: u16,
     pub device_id: u16,
     pub board_id: u16,
-    pub bar_size: u64,
+    pub bar_size: Option<u64>,
 }
 
 impl DeviceInfo {

--- a/crates/luwen-ref/src/lib.rs
+++ b/crates/luwen-ref/src/lib.rs
@@ -65,16 +65,9 @@ impl ExtendedPciDevice {
 
         let default_tlb;
 
-        // Driver 1.33+ will have the allocation APIs enabled
+        // Driver 1.35+ will have the allocation APIs enabled
         // Grayskull does not support the allocation API
-        if device.arch != Arch::Grayskull
-            && ttkmd_if::get_version()
-                >= Some(DriverVersion {
-                    major: 1,
-                    minor: 33,
-                    ..Default::default()
-                })
-        {
+        if device.arch != Arch::Grayskull && device.driver_version >= 2 {
             // Try to allocate progressively smaller TLBs until we find one that looks like it'll work
             let mut size = 1 << 20;
 

--- a/crates/luwencpp/src/lib.rs
+++ b/crates/luwencpp/src/lib.rs
@@ -43,7 +43,6 @@ pub struct DeviceInfo {
 
     pub vendor: u16,
     pub device_id: u16,
-    pub bar_size: u64,
     pub board_id: u16,
 }
 
@@ -57,8 +56,8 @@ impl From<DeviceInfo> for luwen_if::DeviceInfo {
             function: value.function,
             vendor: value.vendor,
             device_id: value.device_id,
-            bar_size: value.bar_size,
             board_id: value.board_id,
+            bar_size: None,
         }
     }
 }

--- a/crates/ttkmd-if/Cargo.toml
+++ b/crates/ttkmd-if/Cargo.toml
@@ -14,3 +14,7 @@ bitfield-struct = "0.6.0"
 
 thiserror = "1.0.40"
 tracing = "0.1.40"
+
+[features]
+test_hardware = []
+test_grayskull = []

--- a/crates/ttkmd-if/src/error.rs
+++ b/crates/ttkmd-if/src/error.rs
@@ -34,9 +34,6 @@ pub enum PciOpenError {
         device_id: usize,
         source: std::io::Error,
     },
-
-    #[error(transparent)]
-    PciError(#[from] PciError),
 }
 
 #[derive(Error, Debug)]
@@ -67,6 +64,7 @@ pub enum PciError {
 
         source: CfgFailType,
     },
+
     #[error("Failed to write into device {id} config space[offset: {offset}, size: {size}]; Failed with {source}")]
     CfgWriteFailed {
         id: usize,
@@ -78,4 +76,16 @@ pub enum PciError {
 
     #[error("Tried to access tlb {id} which is out of range")]
     TlbOutOfRange { id: usize },
+
+    #[error("Failed to reserve tlb for NOC IO; {0}")]
+    TlbAllocationError(String),
+
+    #[error("Ioctl failed with {0}")]
+    IoctlError(Errno),
+
+    #[error("During PciDevice initialization the PCI bar could not be mapped")]
+    BarUnmapped,
+
+    #[error("{0}")]
+    DeviceOpenError(#[from] PciOpenError),
 }

--- a/crates/ttkmd-if/src/ioctl.rs
+++ b/crates/ttkmd-if/src/ioctl.rs
@@ -5,10 +5,18 @@ const TENSTORRENT_IOCTL_MAGIC: usize = 0xFA;
 
 use nix::request_code_none;
 
-#[derive(Default, Debug)]
+#[derive(Debug)]
 #[repr(C)]
 pub struct GetDeviceInfoIn {
     pub output_size_bytes: u32,
+}
+
+impl Default for GetDeviceInfoIn {
+    fn default() -> Self {
+        Self {
+            output_size_bytes: std::mem::size_of::<GetDeviceInfoOut>() as u32,
+        }
+    }
 }
 
 #[derive(Default, Debug)]
@@ -152,10 +160,17 @@ nix::ioctl_readwrite_bad!(
     FreeDmaBuffer
 );
 
-#[derive(Default)]
 #[repr(C)]
 pub struct GetDriverInfoIn {
     pub output_size_bytes: u32,
+}
+
+impl Default for GetDriverInfoIn {
+    fn default() -> Self {
+        Self {
+            output_size_bytes: std::mem::size_of::<GetDriverInfoOut>() as u32,
+        }
+    }
 }
 
 #[derive(Default)]

--- a/crates/ttkmd-if/src/ioctl.rs
+++ b/crates/ttkmd-if/src/ioctl.rs
@@ -5,13 +5,13 @@ const TENSTORRENT_IOCTL_MAGIC: usize = 0xFA;
 
 use nix::request_code_none;
 
-#[derive(Default)]
+#[derive(Default, Debug)]
 #[repr(C)]
 pub struct GetDeviceInfoIn {
     pub output_size_bytes: u32,
 }
 
-#[derive(Default)]
+#[derive(Default, Debug)]
 #[repr(C)]
 pub struct GetDeviceInfoOut {
     pub output_size_bytes: u32,
@@ -24,7 +24,7 @@ pub struct GetDeviceInfoOut {
     pub pci_domain: u16,            // Since 1.23
 }
 
-#[derive(Default)]
+#[derive(Default, Debug)]
 #[repr(C)]
 pub struct GetDeviceInfo {
     pub input: GetDeviceInfoIn,
@@ -215,4 +215,100 @@ nix::ioctl_readwrite_bad!(
     reset_device,
     request_code_none!(TENSTORRENT_IOCTL_MAGIC, 6),
     ResetDevice
+);
+
+#[derive(Default)]
+#[repr(C)]
+pub struct AllocateTlbIn {
+    pub size: u64,
+    pub reserved: u64,
+}
+
+#[derive(Default)]
+#[repr(C)]
+pub struct AllocateTlbOut {
+    pub id: u32,
+    pub reserved0: u32,
+    pub mmap_offset_uc: u64,
+    pub mmap_offset_wc: u64,
+    pub reserved1: u64,
+}
+
+#[derive(Default)]
+#[repr(C)]
+pub struct AllocateTlb {
+    pub input: AllocateTlbIn,
+    pub output: AllocateTlbOut,
+}
+
+nix::ioctl_readwrite_bad!(
+    allocate_tlb,
+    request_code_none!(TENSTORRENT_IOCTL_MAGIC, 11),
+    AllocateTlb
+);
+
+#[derive(Default)]
+#[repr(C)]
+pub struct FreeTlbIn {
+    pub id: u32,
+}
+
+#[derive(Default)]
+#[repr(C)]
+pub struct FreeTlbOut {}
+
+#[derive(Default)]
+#[repr(C)]
+pub struct FreeTlb {
+    pub input: FreeTlbIn,
+    pub output: FreeTlbOut,
+}
+
+nix::ioctl_readwrite_bad!(
+    free_tlb,
+    request_code_none!(TENSTORRENT_IOCTL_MAGIC, 12),
+    FreeTlb
+);
+
+#[derive(Default)]
+#[repr(C)]
+pub struct NocTlbConfig {
+    pub addr: u64,
+    pub x_end: u16,
+    pub y_end: u16,
+    pub x_start: u16,
+    pub y_start: u16,
+    pub noc: u8,
+    pub mcast: u8,
+    pub ordering: u8,
+    pub linked: u8,
+    pub static_vc: u8,
+    pub reserved0: [u8; 3],
+    pub reserved1: [u8; 2],
+}
+
+#[derive(Default)]
+#[repr(C)]
+pub struct ConfigureTlbIn {
+    pub id: u32,
+    pub config: NocTlbConfig,
+}
+
+#[derive(Default)]
+#[repr(C)]
+pub struct ConfigureTlbOut {
+    pub reserved: u64,
+}
+
+#[derive(Default)]
+#[repr(C)]
+pub struct ConfigureTlb {
+    pub input: ConfigureTlbIn,
+    pub output: ConfigureTlbOut,
+}
+
+nix::ioctl_readwrite_bad!(
+    configure_tlb,
+    request_code_none!(TENSTORRENT_IOCTL_MAGIC, 13),
+    ConfigureTlb
 );

--- a/crates/ttkmd-if/src/kmdif.rs
+++ b/crates/ttkmd-if/src/kmdif.rs
@@ -36,6 +36,7 @@ impl MappingId {
     }
 
     pub fn as_u32(&self) -> u32 {
+        // SAFTEY: Need to ensure that the enum has a primitive representation for this to be defined
         unsafe { *(self as *const Self as *const u32) }
     }
 }

--- a/crates/ttkmd-if/src/lib.rs
+++ b/crates/ttkmd-if/src/lib.rs
@@ -68,9 +68,43 @@ pub struct PhysicalDevice {
     pub slot: u16,
     pub pci_function: u16,
     pub pci_domain: u16,
+}
 
+pub struct BarMapping {
     pub bar_addr: u64,
     pub bar_size_bytes: u64,
+
+    pub bar0_uc: memmap2::MmapMut,
+    #[allow(dead_code)]
+    pub bar0_uc_size: u64,
+    pub bar0_uc_offset: u64,
+
+    pub bar0_wc: Option<memmap2::MmapMut>,
+    pub bar0_wc_size: u64,
+
+    pub bar1_uc: Option<memmap2::MmapMut>,
+    pub bar1_uc_size: u64,
+
+    pub system_reg_mapping: Option<memmap2::MmapMut>,
+    #[allow(dead_code)]
+    pub system_reg_mapping_size: usize,
+    pub system_reg_start_offset: u32, // Registers >= this are system regs, use the mapping.
+    pub system_reg_offset_adjust: u32, // This is the offset of the first reg in the system reg mapping.
+}
+
+#[derive(Debug)]
+pub struct TlbAllocation {
+    pub id: u32,
+    pub uc_mapping: memmap2::MmapMut,
+    pub wc_mapping: memmap2::MmapMut,
+    pub size: u64,
+}
+
+#[derive(Debug)]
+pub enum PossibleTlbAllocation {
+    Allocation(TlbAllocation),
+    Hardcoded(u32),
+    NoAllocation,
 }
 
 #[allow(dead_code)]
@@ -86,26 +120,10 @@ pub struct PciDevice {
     next_dma_buf: usize,
 
     device_fd: std::fs::File,
-    bar0_uc: memmap2::MmapMut,
-    #[allow(dead_code)]
-    bar0_uc_size: u64,
-    bar0_uc_offset: u64,
-
-    bar0_wc: Option<memmap2::MmapMut>,
-    bar0_wc_size: u64,
-
-    bar1_uc: Option<memmap2::MmapMut>,
-    bar1_uc_size: u64,
 
     config_space: std::fs::File,
 
     max_dma_buf_size_log2: u16,
-
-    system_reg_mapping: Option<memmap2::MmapMut>,
-    #[allow(dead_code)]
-    system_reg_mapping_size: usize,
-    system_reg_start_offset: u32, // Registers >= this are system regs, use the mapping.
-    system_reg_offset_adjust: u32, // This is the offset of the first reg in the system reg mapping.
 
     #[allow(dead_code)]
     dma_buffer_mappings: Vec<Arc<DmaBuffer>>,
@@ -113,6 +131,7 @@ pub struct PciDevice {
     transfer_buffer: Option<DmaBuffer>,
 
     pub dma_config: Option<DmaConfig>,
+    pub pci_bar: Option<BarMapping>,
 }
 
 fn allocate_dma_buffer(
@@ -161,45 +180,16 @@ fn allocate_dma_buffer(
 }
 
 impl PciDevice {
-    pub fn open(device_id: usize) -> Result<PciDevice, PciOpenError> {
-        let fd = std::fs::OpenOptions::new()
-            .read(true)
-            .write(true)
-            .open(format!("/dev/tenstorrent/{device_id}"));
-        let fd = match fd {
-            Ok(fd) => fd,
-            Err(err) => {
-                return Err(PciOpenError::DeviceOpenFailed {
-                    id: device_id,
-                    source: err,
-                })
-            }
-        };
-
-        let mut device_info = GetDeviceInfo::default();
-        device_info.input.output_size_bytes = std::mem::size_of::<ioctl::GetDeviceInfoOut>() as u32;
-
-        if let Err(errorno) = unsafe { ioctl::get_device_info(fd.as_raw_fd(), &mut device_info) } {
-            return Err(PciOpenError::IoctlError {
-                name: "get_device_info".to_string(),
-                id: device_id,
-                source: errorno,
-            });
-        }
-
-        let max_dma_buf_size_log2 = device_info.output.max_dma_buf_size_log2;
-
+    fn map_bar(&mut self) -> Result<(), PciOpenError> {
         let mut mappings = QueryMappings::<8>::default();
 
-        if let Err(erno) = unsafe { query_mappings(fd.as_raw_fd(), &mut mappings) } {
+        if let Err(erno) = unsafe { query_mappings(self.device_fd.as_raw_fd(), &mut mappings) } {
             return Err(PciOpenError::IoctlError {
                 name: "query_mappings".to_string(),
-                id: device_id,
+                id: self.id,
                 source: erno,
             });
         }
-
-        let arch = Arch::from(&device_info.output);
 
         let mut bar0_uc_mapping = Mapping::default();
         let mut bar0_wc_mapping = Mapping::default();
@@ -240,11 +230,11 @@ impl PciDevice {
         if bar0_uc_mapping.mapping_id != kmdif::MappingId::Resource0Uc.as_u32() {
             return Err(PciOpenError::BarMappingError {
                 name: "bar0_uc_mapping".to_string(),
-                id: device_id,
+                id: self.id,
             });
         }
 
-        let wc_mapping_size = if arch.is_blackhole() {
+        let wc_mapping_size = if self.arch.is_blackhole() {
             kmdif::BH_BAR0_WC_MAPPING_SIZE
         } else {
             kmdif::GS_BAR0_WC_MAPPING_SIZE
@@ -262,14 +252,17 @@ impl PciDevice {
                 memmap2::MmapOptions::default()
                     .len(bar0_wc_size as usize)
                     .offset(bar0_wc_mapping.mapping_base)
-                    .map_mut(fd.as_raw_fd())
+                    .map_mut(self.device_fd.as_raw_fd())
             };
             match bar0_wc_map {
                 Ok(map) => {
                     bar0_wc = Some(map);
                 }
                 Err(err) => {
-                    println!("WARNING: Failed to map bar0_wc for {device_id} with error {err}");
+                    println!(
+                        "WARNING: Failed to map bar0_wc for {} with error {err}",
+                        self.id
+                    );
                     bar0_wc_size = 0;
                     bar0_wc = None;
                 }
@@ -291,12 +284,12 @@ impl PciDevice {
             memmap2::MmapOptions::default()
                 .len(bar0_uc_size as usize)
                 .offset(bar0_uc_mapping.mapping_base + bar0_uc_offset)
-                .map_mut(fd.as_raw_fd())
+                .map_mut(self.device_fd.as_raw_fd())
         };
         let bar0_uc = match bar0_uc {
             Ok(map) => map,
             Err(err) => {
-                panic!("Failed to map bar0_uc for {device_id} with error {err}");
+                panic!("Failed to map bar0_uc for {} with error {err}", self.id);
             }
         };
 
@@ -310,9 +303,9 @@ impl PciDevice {
         let mut system_reg_start_offset = 0;
         let mut system_reg_offset_adjust = 0;
         let mut system_reg_mapping = None;
-        if arch.is_wormhole() {
+        if self.arch.is_wormhole() {
             if bar2_uc_mapping.mapping_id != kmdif::MappingId::Resource2Uc.as_u32() {
-                panic!("Device {device_id} has no BAR4 mapping");
+                panic!("Device {} has no BAR4 mapping", self.id);
             }
 
             system_reg_mapping_size = bar2_uc_mapping.mapping_size as usize;
@@ -320,12 +313,15 @@ impl PciDevice {
                 memmap2::MmapOptions::default()
                     .len(system_reg_mapping_size)
                     .offset(bar2_uc_mapping.mapping_base)
-                    .map_mut(fd.as_raw_fd())
+                    .map_mut(self.device_fd.as_raw_fd())
             };
             system_reg_mapping = match system_reg {
                 Ok(map) => Some(map),
                 Err(err) => {
-                    panic!("BAR4 mapping failed for device {device_id} with error {err}");
+                    panic!(
+                        "BAR4 mapping failed for device {} with error {err}",
+                        self.id
+                    );
                 }
             };
 
@@ -335,9 +331,9 @@ impl PciDevice {
 
         let mut bar1_uc = None;
         let mut bar1_uc_size = 0;
-        if arch.is_blackhole() {
+        if self.arch.is_blackhole() {
             if bar1_uc_mapping.mapping_id != kmdif::MappingId::Resource1Uc.as_u32() {
-                panic!("Device {device_id} has not Bar1 UC mapping");
+                panic!("Device {} has not Bar1 UC mapping", self.id);
             }
 
             bar1_uc_size = bar1_uc_mapping.mapping_size;
@@ -345,10 +341,60 @@ impl PciDevice {
                 memmap2::MmapOptions::default()
                     .len(bar1_uc_mapping.mapping_size as usize)
                     .offset(bar1_uc_mapping.mapping_base)
-                    .map_mut(fd.as_raw_fd())
+                    .map_mut(self.device_fd.as_raw_fd())
                     .expect("Bar1 mapping failed for device {device_id}")
             });
         }
+
+        self.pci_bar = Some(BarMapping {
+            bar_addr: pci::read_bar0_base(&self.config_space),
+            bar_size_bytes: bar0_uc_mapping.mapping_size,
+
+            bar0_uc,
+            bar0_uc_size,
+            bar0_uc_offset,
+            bar0_wc,
+            bar0_wc_size,
+            bar1_uc,
+            bar1_uc_size,
+            system_reg_mapping,
+            system_reg_mapping_size,
+            system_reg_start_offset,
+            system_reg_offset_adjust,
+        });
+
+        Ok(())
+    }
+
+    pub fn open(device_id: usize) -> Result<PciDevice, PciOpenError> {
+        let fd = std::fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(format!("/dev/tenstorrent/{device_id}"));
+        let fd = match fd {
+            Ok(fd) => fd,
+            Err(err) => {
+                return Err(PciOpenError::DeviceOpenFailed {
+                    id: device_id,
+                    source: err,
+                })
+            }
+        };
+
+        let mut device_info = GetDeviceInfo::default();
+        device_info.input.output_size_bytes = std::mem::size_of::<ioctl::GetDeviceInfoOut>() as u32;
+
+        if let Err(errorno) = unsafe { ioctl::get_device_info(fd.as_raw_fd(), &mut device_info) } {
+            return Err(PciOpenError::IoctlError {
+                name: "get_device_info".to_string(),
+                id: device_id,
+                source: errorno,
+            });
+        }
+
+        let arch = Arch::from(&device_info.output);
+
+        let max_dma_buf_size_log2 = device_info.output.max_dma_buf_size_log2;
 
         let pci_bus = device_info.output.bus_dev_fn >> 8;
         let slot = ((device_info.output.bus_dev_fn) >> 3) & 0x1f; // The definition of PCI_SLOT from include/uapi/linux/pci.h
@@ -382,8 +428,6 @@ impl PciDevice {
                 slot,
                 pci_function,
                 pci_domain,
-                bar_addr: pci::read_bar0_base(&config_space),
-                bar_size_bytes: bar0_uc_mapping.mapping_size,
             },
 
             read_checking_enabled: true,
@@ -397,34 +441,24 @@ impl PciDevice {
 
             device_fd: fd,
 
-            bar0_uc,
-            bar0_uc_size,
-            bar0_uc_offset,
-
-            bar0_wc,
-            bar0_wc_size,
-
-            bar1_uc,
-            bar1_uc_size,
-
             config_space,
 
             max_dma_buf_size_log2,
-
-            system_reg_mapping,
-            system_reg_mapping_size,
-            system_reg_start_offset,
-            system_reg_offset_adjust,
 
             dma_buffer_mappings: vec![],
             dma_config: None,
             completion_flag_buffer: None,
             transfer_buffer: None,
+
+            pci_bar: None,
         };
 
         // To avoid needing a warmup when performing the first dma access, try to allocate the
         // buffers now.
         device.allocate_transfer_buffers();
+
+        // If/when the raw bar mapping is removed this will start failing
+        device.map_bar()?;
 
         Ok(device)
     }
@@ -489,6 +523,102 @@ impl PciDevice {
         self.allocate_dma_buffer_range(size, size)
     }
 
+    pub fn allocate_tlb(&self, size: u64) -> Result<TlbAllocation, PciError> {
+        let mut data = ioctl::AllocateTlb {
+            input: ioctl::AllocateTlbIn {
+                size,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let result =
+            unsafe { ioctl::allocate_tlb(self.device_fd.as_raw_fd(), (&mut data) as *mut _) };
+
+        let uc_mapping = unsafe {
+            memmap2::MmapOptions::default()
+                .len(size as usize)
+                .offset(data.output.mmap_offset_uc)
+                .map_mut(self.device_fd.as_raw_fd())
+        }
+        .map_err(|_err| PciError::TlbAllocationError("Failed to map uc buffer".to_string()))?;
+
+        let wc_mapping = unsafe {
+            memmap2::MmapOptions::default()
+                .len(size as usize)
+                .offset(data.output.mmap_offset_wc)
+                .map_mut(self.device_fd.as_raw_fd())
+        }
+        .map_err(|_err| PciError::TlbAllocationError("Failed to map wc buffer".to_string()))?;
+
+        match result {
+            Ok(rc) => match rc {
+                0 => Ok(TlbAllocation {
+                    id: data.output.id,
+                    uc_mapping,
+                    wc_mapping,
+                    size,
+                }),
+                errno => Err(PciError::IoctlError(nix::errno::Errno::from_i32(errno))),
+            },
+            Err(errno) => Err(PciError::IoctlError(errno)),
+        }
+    }
+
+    pub fn free_tlb(&self, alloc: &TlbAllocation) -> Result<bool, PciError> {
+        let result = unsafe {
+            ioctl::free_tlb(
+                self.device_fd.as_raw_fd(),
+                (&mut ioctl::FreeTlb {
+                    input: ioctl::FreeTlbIn { id: alloc.id },
+                    output: ioctl::FreeTlbOut {},
+                }) as *mut _,
+            )
+        };
+
+        match result {
+            Ok(rc) => match rc {
+                0 => Ok(true),
+                _ => Ok(false),
+            },
+            Err(errno) => match errno {
+                nix::errno::Errno::EINVAL => Ok(false),
+                errno => Err(PciError::IoctlError(errno)),
+            },
+        }
+    }
+
+    pub fn configure_tlb(
+        &self,
+        alloc: &TlbAllocation,
+        config: ioctl::NocTlbConfig,
+    ) -> Result<bool, PciError> {
+        let result = unsafe {
+            ioctl::configure_tlb(
+                self.device_fd.as_raw_fd(),
+                (&mut ioctl::ConfigureTlb {
+                    input: ioctl::ConfigureTlbIn {
+                        id: alloc.id,
+                        config,
+                    },
+                    output: ioctl::ConfigureTlbOut {
+                        ..Default::default()
+                    },
+                }) as *mut _,
+            )
+        };
+
+        match result {
+            Ok(rc) => match rc {
+                0 => Ok(true),
+                _ => Ok(false),
+            },
+            Err(errno) => match errno {
+                nix::errno::Errno::EINVAL => Ok(false),
+                errno => Err(PciError::IoctlError(errno)),
+            },
+        }
+    }
+
     pub fn scan() -> Vec<usize> {
         let output = std::fs::read_dir("/dev/tenstorrent");
         let output = match output {
@@ -516,5 +646,313 @@ impl PciDevice {
         output.sort();
 
         output
+    }
+
+    pub fn setup_tlb(
+        &mut self,
+        index: &PossibleTlbAllocation,
+        tlb: Tlb,
+    ) -> Result<(u64, u64), PciError> {
+        match index {
+            PossibleTlbAllocation::Allocation(tlb_allocation) => {
+                let config = ioctl::NocTlbConfig {
+                    addr: tlb.local_offset & !(tlb_allocation.size - 1),
+                    x_end: tlb.x_end as u16,
+                    y_end: tlb.y_end as u16,
+                    x_start: tlb.x_start as u16,
+                    y_start: tlb.y_start as u16,
+                    noc: tlb.noc_sel,
+                    mcast: tlb.mcast as u8,
+                    ordering: tlb.ordering.into(),
+                    linked: tlb.linked as u8,
+                    static_vc: tlb.static_vc,
+                    ..Default::default()
+                };
+                self.configure_tlb(tlb_allocation, config)?;
+
+                // The tlb addr selects the upper bits of the final noc addrress
+                // therefore the lower bits are the offset into the tlb itself, selected by the lower bits of our size.
+                let tlb_offset = tlb.local_offset & (tlb_allocation.size - 1);
+
+                Ok((
+                    tlb_offset,
+                    // The size must be shrunk by the offset into the tlb of our configured address
+                    tlb_allocation.size - tlb_offset,
+                ))
+            }
+            PossibleTlbAllocation::Hardcoded(index) => tlb::setup_tlb(self, *index, tlb),
+            PossibleTlbAllocation::NoAllocation => {
+                todo!("Need all fallback implementation if a tlb was not otherwise selected")
+            }
+        }
+    }
+
+    pub fn get_tlb(&self, index: &PossibleTlbAllocation) -> Result<Tlb, PciError> {
+        let index = match index {
+            PossibleTlbAllocation::Allocation(tlb_allocation) => tlb_allocation.id,
+            PossibleTlbAllocation::Hardcoded(index) => *index,
+            PossibleTlbAllocation::NoAllocation => {
+                todo!("Need all fallback implementation if a tlb was not otherwise selected")
+            }
+        };
+
+        tlb::get_tlb(self, index)
+    }
+
+    pub fn noc_write(
+        &mut self,
+        index: &PossibleTlbAllocation,
+        mut tlb: Tlb,
+        data: &[u8],
+    ) -> Result<(), PciError> {
+        let mut written = 0;
+        let addr = tlb.local_offset;
+        while written < data.len() {
+            let (offset, size) = self.setup_tlb(index, tlb.clone())?;
+
+            let to_read = &data[written..];
+            let to_read = &data[..(size as usize).min(to_read.len())];
+
+            match index {
+                PossibleTlbAllocation::Allocation(tlb_allocation) => unsafe {
+                    Self::memcpy_to_device(
+                        (tlb_allocation.uc_mapping.as_ptr() as *mut u8).byte_add(offset as usize),
+                        to_read,
+                    );
+                },
+                PossibleTlbAllocation::Hardcoded(_index) => {
+                    self.write_block(offset as u32, to_read)?;
+                }
+                PossibleTlbAllocation::NoAllocation => todo!(),
+            }
+
+            written += to_read.len();
+
+            tlb.local_offset = addr + written as u64;
+        }
+
+        Ok(())
+    }
+
+    pub fn noc_read(
+        &mut self,
+        index: &PossibleTlbAllocation,
+        mut tlb: Tlb,
+        data: &mut [u8],
+    ) -> Result<(), PciError> {
+        let mut read = 0;
+        let addr = tlb.local_offset;
+        while read < data.len() {
+            let (offset, size) = self.setup_tlb(index, tlb.clone())?;
+
+            let to_read = {
+                let to_read = &mut data[read..];
+                let read_len = to_read.len();
+                &mut data[..(size as usize).min(read_len)]
+            };
+
+            match index {
+                PossibleTlbAllocation::Allocation(tlb_allocation) => unsafe {
+                    Self::memcpy_from_device(
+                        to_read,
+                        (tlb_allocation.uc_mapping.as_ptr() as *mut u8).byte_add(offset as usize),
+                    );
+                },
+                PossibleTlbAllocation::Hardcoded(_index) => {
+                    self.write_block(offset as u32, to_read)?;
+                }
+                PossibleTlbAllocation::NoAllocation => todo!(),
+            }
+
+            read += to_read.len();
+
+            tlb.local_offset = addr + read as u64;
+        }
+
+        Ok(())
+    }
+
+    pub fn noc_write32(
+        &mut self,
+        tlb_index: &PossibleTlbAllocation,
+        tlb: Tlb,
+        data: u32,
+    ) -> Result<(), PciError> {
+        let (offset, size) = self.setup_tlb(tlb_index, tlb)?;
+        assert!(
+            size >= 4,
+            "We have hit the the unlikely case of size being less than 4 bytes; this should not be possible"
+        );
+        match tlb_index {
+            PossibleTlbAllocation::Allocation(tlb_allocation) => self.write32_no_translation(
+                unsafe {
+                    (tlb_allocation.uc_mapping.as_ptr() as *mut u8).byte_add(offset as usize)
+                        as usize
+                },
+                data,
+            ),
+            PossibleTlbAllocation::Hardcoded(_) => self.write32(offset as u32, data),
+            PossibleTlbAllocation::NoAllocation => todo!(),
+        }
+    }
+
+    pub fn noc_read32(
+        &mut self,
+        tlb_index: &PossibleTlbAllocation,
+        tlb: Tlb,
+    ) -> Result<u32, PciError> {
+        let (offset, size) = self.setup_tlb(tlb_index, tlb)?;
+        assert!(
+            size >= 4,
+            "We have hit the the unlikely case of size being less than 4 bytes; this should not be possible"
+        );
+        match tlb_index {
+            PossibleTlbAllocation::Allocation(tlb_allocation) => {
+                self.read32_no_translation(unsafe {
+                    (tlb_allocation.uc_mapping.as_ptr() as *mut u8).byte_add(offset as usize)
+                        as usize
+                })
+            }
+            PossibleTlbAllocation::Hardcoded(_) => self.read32(offset as u32),
+            PossibleTlbAllocation::NoAllocation => todo!(),
+        }
+    }
+}
+
+#[derive(Default, PartialEq)]
+pub struct DriverVersion {
+    pub major: u32,
+    pub minor: u32,
+    pub patch: u32,
+    pub quirk: Option<String>,
+}
+
+impl PartialOrd for DriverVersion {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        match self.major.cmp(&other.major) {
+            std::cmp::Ordering::Equal => match self.minor.cmp(&other.minor) {
+                std::cmp::Ordering::Equal => match self.patch.cmp(&other.patch) {
+                    std::cmp::Ordering::Equal => {
+                        if self.quirk == other.quirk {
+                            Some(std::cmp::Ordering::Equal)
+                        } else {
+                            None
+                        }
+                    }
+                    other => Some(other),
+                },
+                other => Some(other),
+            },
+            other => Some(other),
+        }
+    }
+}
+
+pub fn get_version() -> Option<DriverVersion> {
+    std::fs::read_to_string("/sys/module/tenstorrent/version")
+        .ok()
+        .map(|version| {
+            let mut driver_version = DriverVersion::default();
+            let version = version.trim();
+
+            let version = if let Some((a, b)) = version.split_once('-') {
+                driver_version.quirk = Some(b.to_string());
+
+                a
+            } else {
+                version
+            };
+
+            let mut it = version.splitn(3, '.');
+            if let Some(v) = it.next() {
+                if let Ok(v) = v.parse() {
+                    driver_version.major = v;
+                }
+            }
+            if let Some(v) = it.next() {
+                if let Ok(v) = v.parse() {
+                    driver_version.minor = v;
+                }
+            }
+            if let Some(v) = it.next() {
+                if let Ok(v) = v.parse() {
+                    driver_version.patch = v;
+                }
+            }
+
+            driver_version
+        })
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    fn verify_noc(device: &mut PciDevice, tlb: PossibleTlbAllocation) {
+        let node_info = match device.arch {
+            Arch::Grayskull => {
+                unimplemented!("Not currently supporting GS for this test\nTo support readback the noc node id from ARC");
+            }
+            Arch::Wormhole => (0, 10, 0xFFFB2002C),
+            Arch::Blackhole => (8, 0, 0x0000000080050044),
+            Arch::Unknown(_) => todo!(),
+        };
+
+        let node_id = device
+            .noc_read32(
+                &tlb,
+                Tlb {
+                    x_end: node_info.0,
+                    y_end: node_info.1,
+                    noc_sel: 0,
+
+                    local_offset: node_info.2,
+
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+        let x = node_id & 0x3f;
+        let y = (node_id >> 6) & 0x3f;
+
+        assert!(
+            x == node_info.0 as u32 && y == node_info.1 as u32,
+            "ARC node id didn't match expected ({x}, {y}) != ({}, {})",
+            node_info.0,
+            node_info.1
+        );
+    }
+
+    #[test]
+    #[cfg_attr(
+        any(not(feature = "test_hardware"), feature = "test_grayskull"),
+        ignore = "Requires hardware"
+    )]
+    fn ttkmd_allocate() {
+        let mut device = PciDevice::scan()
+            .into_iter()
+            .map(PciDevice::open)
+            .next()
+            .expect("Expected to have access to 1 pci device")
+            .unwrap();
+
+        let tlb = device.allocate_tlb(1 << 20).unwrap();
+        verify_noc(&mut device, PossibleTlbAllocation::Allocation(tlb));
+    }
+
+    #[test]
+    #[cfg_attr(
+        any(not(feature = "test_hardware"), feature = "test_grayskull"),
+        ignore = "Requires hardware"
+    )]
+    fn ttkmd_no_allocate() {
+        let mut device = PciDevice::scan()
+            .into_iter()
+            .map(PciDevice::open)
+            .next()
+            .expect("Expected to have access to 1 pci device")
+            .unwrap();
+
+        verify_noc(&mut device, PossibleTlbAllocation::Hardcoded(1));
     }
 }

--- a/src/bin/luwen-demo.rs
+++ b/src/bin/luwen-demo.rs
@@ -44,8 +44,8 @@ pub fn main() -> Result<(), LuwenError> {
                     write_threshold: 0,
                 });
 
-                let (offset, _size) = pci_interface.setup_tlb(
-                    168,
+                let (offset, _size) = pci_interface.device.setup_tlb(
+                    &ttkmd_if::PossibleTlbAllocation::Hardcoded(168),
                     Tlb {
                         local_offset: 0x0,
                         x_end: 1,


### PR DESCRIPTION
kmd 1.33 added support for reserving tlbs. This adds that functionality into luwen, currently there is no fallback if the tlbs are all reserved, so in that case we just bail.