### PR TITLE
Added support for BH style broadcast

### DIFF
--- a/crates/luwen-if/src/chip/blackhole.rs
+++ b/crates/luwen-if/src/chip/blackhole.rs
@@ -687,6 +687,9 @@ impl ChipImpl for Blackhole {
                     TelemetryTags::EnabledGddr => telemetry_data.enabled_gddr = data,
                     TelemetryTags::EnabledL2Cpu => telemetry_data.enabled_l2cpu = data,
                     TelemetryTags::PcieUsage => telemetry_data.enabled_pcie = data,
+                    TelemetryTags::NocTranslation => {
+                        telemetry_data.noc_translation_enabled = data != 0
+                    }
                     _ => (),
                 }
             }

--- a/crates/luwen-if/src/chip/blackhole/telemetry_tags.rs
+++ b/crates/luwen-if/src/chip/blackhole/telemetry_tags.rs
@@ -41,4 +41,5 @@ pub enum TelemetryTags {
     EnabledGddr = 36,
     EnabledL2Cpu = 37,
     PcieUsage = 38,
+    NocTranslation = 40,
 }

--- a/crates/luwen-if/src/chip/communication/chip_comms.rs
+++ b/crates/luwen-if/src/chip/communication/chip_comms.rs
@@ -101,6 +101,15 @@ pub trait ChipComms {
         addr: u64,
         data: &[u8],
     ) -> Result<(), Box<dyn std::error::Error>>;
+    fn noc_multicast(
+        &self,
+        chip_if: &dyn ChipInterface,
+        noc_id: u8,
+        start: (u8, u8),
+        end: (u8, u8),
+        addr: u64,
+        data: &[u8],
+    ) -> Result<(), Box<dyn std::error::Error>>;
     fn noc_broadcast(
         &self,
         chip_if: &dyn ChipInterface,
@@ -133,6 +142,25 @@ pub trait ChipComms {
         value: u32,
     ) -> Result<(), Box<dyn std::error::Error>> {
         self.noc_write(chip_if, noc_id, x, y, addr, value.to_le_bytes().as_slice())
+    }
+
+    fn noc_multicast32(
+        &self,
+        chip_if: &dyn ChipInterface,
+        noc_id: u8,
+        start: (u8, u8),
+        end: (u8, u8),
+        addr: u64,
+        value: u32,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        self.noc_multicast(
+            chip_if,
+            noc_id,
+            start,
+            end,
+            addr,
+            value.to_le_bytes().as_slice(),
+        )
     }
 
     fn noc_broadcast32(
@@ -317,6 +345,18 @@ impl ChipComms for ArcIf {
         chip_if.noc_write(noc_id, x, y, addr, data)
     }
 
+    fn noc_multicast(
+        &self,
+        chip_if: &dyn ChipInterface,
+        noc_id: u8,
+        start: (u8, u8),
+        end: (u8, u8),
+        addr: u64,
+        data: &[u8],
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        chip_if.noc_multicast(noc_id, start, end, addr, data)
+    }
+
     fn noc_broadcast(
         &self,
         chip_if: &dyn ChipInterface,
@@ -382,6 +422,18 @@ impl ChipComms for NocIf {
         chip_if.noc_write(noc_id, x, y, addr, data)
     }
 
+    fn noc_multicast(
+        &self,
+        chip_if: &dyn ChipInterface,
+        noc_id: u8,
+        start: (u8, u8),
+        end: (u8, u8),
+        addr: u64,
+        data: &[u8],
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        chip_if.noc_multicast(noc_id, start, end, addr, data)
+    }
+
     fn noc_broadcast(
         &self,
         chip_if: &dyn ChipInterface,
@@ -440,6 +492,19 @@ impl ChipComms for Arc<dyn ChipComms> {
         self.as_ref().noc_write(chip_if, noc_id, x, y, addr, data)
     }
 
+    fn noc_multicast(
+        &self,
+        chip_if: &dyn ChipInterface,
+        noc_id: u8,
+        start: (u8, u8),
+        end: (u8, u8),
+        addr: u64,
+        data: &[u8],
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        self.as_ref()
+            .noc_multicast(chip_if, noc_id, start, end, addr, data)
+    }
+
     fn noc_broadcast(
         &self,
         chip_if: &dyn ChipInterface,
@@ -496,6 +561,19 @@ impl ChipComms for Arc<dyn ChipComms + Send + Sync> {
         data: &[u8],
     ) -> Result<(), Box<dyn std::error::Error>> {
         self.as_ref().noc_write(chip_if, noc_id, x, y, addr, data)
+    }
+
+    fn noc_multicast(
+        &self,
+        chip_if: &dyn ChipInterface,
+        noc_id: u8,
+        start: (u8, u8),
+        end: (u8, u8),
+        addr: u64,
+        data: &[u8],
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        self.as_ref()
+            .noc_multicast(chip_if, noc_id, start, end, addr, data)
     }
 
     fn noc_broadcast(

--- a/crates/luwen-if/src/chip/communication/chip_interface.rs
+++ b/crates/luwen-if/src/chip/communication/chip_interface.rs
@@ -43,6 +43,14 @@ pub trait ChipInterface: 'static {
         addr: u64,
         data: &[u8],
     ) -> Result<(), Box<dyn std::error::Error>>;
+    fn noc_multicast(
+        &self,
+        noc_id: u8,
+        start: (u8, u8),
+        end: (u8, u8),
+        addr: u64,
+        data: &[u8],
+    ) -> Result<(), Box<dyn std::error::Error>>;
 
     /// Read and write to a noc endpoint via ethernet on a local or remote chip.
     fn eth_noc_read(
@@ -60,6 +68,15 @@ pub trait ChipInterface: 'static {
         noc_id: u8,
         x: u8,
         y: u8,
+        addr: u64,
+        data: &[u8],
+    ) -> Result<(), Box<dyn std::error::Error>>;
+    fn eth_noc_multicast(
+        &self,
+        eth_addr: EthAddr,
+        noc_id: u8,
+        start: (u8, u8),
+        end: (u8, u8),
         addr: u64,
         data: &[u8],
     ) -> Result<(), Box<dyn std::error::Error>>;
@@ -109,6 +126,17 @@ impl ChipInterface for Arc<dyn ChipInterface + Send + Sync> {
         self.as_ref().noc_write(noc_id, x, y, addr, data)
     }
 
+    fn noc_multicast(
+        &self,
+        noc_id: u8,
+        start: (u8, u8),
+        end: (u8, u8),
+        addr: u64,
+        data: &[u8],
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        self.as_ref().noc_multicast(noc_id, start, end, addr, data)
+    }
+
     fn noc_broadcast(
         &self,
         noc_id: u8,
@@ -142,6 +170,19 @@ impl ChipInterface for Arc<dyn ChipInterface + Send + Sync> {
     ) -> Result<(), Box<dyn std::error::Error>> {
         self.as_ref()
             .eth_noc_write(eth_addr, noc_id, x, y, addr, data)
+    }
+
+    fn eth_noc_multicast(
+        &self,
+        eth_addr: EthAddr,
+        noc_id: u8,
+        start: (u8, u8),
+        end: (u8, u8),
+        addr: u64,
+        data: &[u8],
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        self.as_ref()
+            .eth_noc_multicast(eth_addr, noc_id, start, end, addr, data)
     }
 
     fn eth_noc_broadcast(
@@ -205,6 +246,17 @@ impl ChipInterface for NocInterface {
         self.backing.noc_write(noc_id, x, y, addr, data)
     }
 
+    fn noc_multicast(
+        &self,
+        noc_id: u8,
+        start: (u8, u8),
+        end: (u8, u8),
+        addr: u64,
+        data: &[u8],
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        self.backing.noc_multicast(noc_id, start, end, addr, data)
+    }
+
     fn noc_broadcast(
         &self,
         noc_id: u8,
@@ -238,6 +290,19 @@ impl ChipInterface for NocInterface {
     ) -> Result<(), Box<dyn std::error::Error>> {
         self.backing
             .eth_noc_write(eth_addr, noc_id, x, y, addr, data)
+    }
+
+    fn eth_noc_multicast(
+        &self,
+        eth_addr: EthAddr,
+        noc_id: u8,
+        start: (u8, u8),
+        end: (u8, u8),
+        addr: u64,
+        data: &[u8],
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        self.backing
+            .eth_noc_multicast(eth_addr, noc_id, start, end, addr, data)
     }
 
     fn eth_noc_broadcast(

--- a/crates/luwen-if/src/chip/hl_comms.rs
+++ b/crates/luwen-if/src/chip/hl_comms.rs
@@ -33,6 +33,18 @@ pub trait HlComms {
         arc_if.noc_write(chip_if, noc_id, x, y, addr, data)
     }
 
+    fn noc_multicast(
+        &self,
+        noc_id: u8,
+        start: (u8, u8),
+        end: (u8, u8),
+        addr: u64,
+        data: &[u8],
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let (_, chip_if) = self.comms_obj();
+        chip_if.noc_multicast(noc_id, start, end, addr, data)
+    }
+
     fn noc_broadcast(
         &self,
         noc_id: u8,

--- a/crates/luwen-if/src/chip/mod.rs
+++ b/crates/luwen-if/src/chip/mod.rs
@@ -128,6 +128,7 @@ pub struct Telemetry {
     pub tt_flash_version: u32,
     pub fw_bundle_version: u32,
     pub timer_heartbeat: u32,
+    pub noc_translation_enabled: bool,
     pub tensix_enabled_col: u32,
     pub enabled_eth: u32,
     pub enabled_gddr: u32,

--- a/crates/luwen-if/src/chip/remote.rs
+++ b/crates/luwen-if/src/chip/remote.rs
@@ -62,6 +62,18 @@ impl ChipComms for RemoteArcIf {
         chip_if.eth_noc_write(self.addr, noc_id, x, y, addr, data)
     }
 
+    fn noc_multicast(
+        &self,
+        chip_if: &dyn ChipInterface,
+        noc_id: u8,
+        start: (u8, u8),
+        end: (u8, u8),
+        addr: u64,
+        data: &[u8],
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        chip_if.eth_noc_multicast(self.addr, noc_id, start, end, addr, data)
+    }
+
     fn noc_broadcast(
         &self,
         chip_if: &dyn ChipInterface,

--- a/crates/luwen-if/src/interface.rs
+++ b/crates/luwen-if/src/interface.rs
@@ -22,6 +22,16 @@ pub enum FnNoc {
         data: *const u8,
         len: u64,
     },
+    Multicast {
+        noc_id: u8,
+        start_x: u8,
+        start_y: u8,
+        end_x: u8,
+        end_y: u8,
+        addr: u64,
+        data: *const u8,
+        len: u64,
+    },
     Broadcast {
         noc_id: u8,
         addr: u64,
@@ -232,6 +242,29 @@ impl<T: Clone + Send + 'static> ChipInterface for CallbackStorage<T> {
         )
     }
 
+    fn noc_multicast(
+        &self,
+        noc_id: u8,
+        start: (u8, u8),
+        end: (u8, u8),
+        addr: u64,
+        data: &[u8],
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        (self.callback)(
+            &self.user_data,
+            FnOptions::Noc(FnNoc::Multicast {
+                noc_id,
+                start_x: start.0,
+                start_y: start.1,
+                end_x: end.0,
+                end_y: end.1,
+                addr,
+                data: data.as_ptr(),
+                len: data.len() as u64,
+            }),
+        )
+    }
+
     fn noc_broadcast(
         &self,
         noc_id: u8,
@@ -291,6 +324,33 @@ impl<T: Clone + Send + 'static> ChipInterface for CallbackStorage<T> {
                     noc_id,
                     x: x as u32,
                     y: y as u32,
+                    addr,
+                    data: data.as_ptr(),
+                    len: data.len() as u64,
+                },
+            }),
+        )
+    }
+
+    fn eth_noc_multicast(
+        &self,
+        eth_addr: EthAddr,
+        noc_id: u8,
+        start: (u8, u8),
+        end: (u8, u8),
+        addr: u64,
+        data: &[u8],
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        (self.callback)(
+            &self.user_data,
+            FnOptions::Eth(FnRemote {
+                addr: eth_addr,
+                rw: FnNoc::Multicast {
+                    noc_id,
+                    start_x: start.0,
+                    start_y: start.1,
+                    end_x: end.0,
+                    end_y: end.1,
                     addr,
                     data: data.as_ptr(),
                     len: data.len() as u64,

--- a/crates/luwencpp/src/lib.rs
+++ b/crates/luwencpp/src/lib.rs
@@ -95,6 +95,17 @@ pub struct LuwenGlue {
         len: u64,
         user_data: *mut std::ffi::c_void,
     ),
+    noc_multicast: extern "C" fn(
+        noc_id: u8,
+        start_x: u8,
+        start_y: u8,
+        end_x: u8,
+        end_y: u8,
+        addr: u64,
+        data: *const u8,
+        len: u64,
+        user_data: *mut std::ffi::c_void,
+    ),
     noc_broadcast: extern "C" fn(
         noc_id: u8,
         addr: u64,
@@ -120,6 +131,18 @@ pub struct LuwenGlue {
         noc_id: u8,
         x: u32,
         y: u32,
+        addr: u64,
+        data: *const u8,
+        len: u64,
+        user_data: *mut std::ffi::c_void,
+    ),
+    eth_multicast: extern "C" fn(
+        eth_addr: EthAddr,
+        noc_id: u8,
+        start_x: u8,
+        start_y: u8,
+        end_x: u8,
+        end_y: u8,
         addr: u64,
         data: *const u8,
         len: u64,
@@ -197,6 +220,29 @@ pub fn callback_glue(
                 (glue_data.noc_broadcast)(noc_id, addr, data, len, glue_data.user_data);
                 Ok(())
             }
+            luwen_if::FnNoc::Multicast {
+                noc_id,
+                start_x,
+                start_y,
+                end_x,
+                end_y,
+                addr,
+                data,
+                len,
+            } => {
+                (glue_data.noc_multicast)(
+                    noc_id,
+                    start_x,
+                    start_y,
+                    end_x,
+                    end_y,
+                    addr,
+                    data,
+                    len,
+                    glue_data.user_data,
+                );
+                Ok(())
+            }
         },
         FnOptions::Eth(op) => match op.rw {
             luwen_if::FnNoc::Read {
@@ -263,6 +309,35 @@ pub fn callback_glue(
                         rack_y: op.addr.rack_y,
                     },
                     noc_id,
+                    addr,
+                    data,
+                    len,
+                    glue_data.user_data,
+                );
+                Ok(())
+            }
+            luwen_if::FnNoc::Multicast {
+                noc_id,
+                start_x,
+                start_y,
+                end_x,
+                end_y,
+                addr,
+                data,
+                len,
+            } => {
+                (glue_data.eth_multicast)(
+                    EthAddr {
+                        shelf_x: op.addr.shelf_x,
+                        shelf_y: op.addr.shelf_y,
+                        rack_x: op.addr.rack_x,
+                        rack_y: op.addr.rack_y,
+                    },
+                    noc_id,
+                    start_x,
+                    start_y,
+                    end_x,
+                    end_y,
                     addr,
                     data,
                     len,


### PR DESCRIPTION
The BH broadcast when cooridnates are translated requiring different coordiantes to be programmed and not allowing backwards compatibility with untranslated coordinates breaks some fundimental assumptions backed in the luwen's design. Instead of rewriting these assumptions I opted to support this broadcast for the one case I currently care about (burnin) and develop a more comprehensive redeisgn in a seperate branch.