### PR TITLE
Bump luwen and pyluwen version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "luwen"
-version = "0.6.4"
+version = "0.6.5"
 description = "A high-level interface for safe and efficient access Tenstorrent AI accelerators"
 edition = "2021"
 license = "Apache-2.0"

--- a/crates/pyluwen/Cargo.toml
+++ b/crates/pyluwen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyluwen"
-version = "0.7.2"
+version = "0.7.3"
 description = "Python bindings for luwen"
 edition = "2021"
 license = "Apache-2.0"


### PR DESCRIPTION
For tt-smi to be able to pull in new versions that have bh harvesting info in telemetry

luwen: 0.6.4->0.6.5
pyluwen: 0.7.2->0.7.3