### PR TITLE
bug(pyluwen): removed the unwrap on the device open

### DIFF
--- a/crates/pyluwen/src/lib.rs
+++ b/crates/pyluwen/src/lib.rs
@@ -1744,14 +1744,14 @@ fn serde_json_value_to_pyobject(py: Python, value: &Value) -> PyResult<PyObject>
         Value::Null => Ok(py.None()),
         Value::Bool(b) => Ok(b.into_py(py)),
         Value::Number(n) => {
-            if n.is_i64() {
-                Ok(n.as_i64().unwrap().into_py(py))
-            } else if n.is_u64() {
-                Ok(n.as_u64().unwrap().into_py(py))
-            } else if n.is_f64() {
-                Ok(n.as_f64().unwrap().into_py(py))
+            if let Some(value) = n.as_i64() {
+                Ok(value.into_py(py))
+            } else if let Some(value) = n.as_u64() {
+                Ok(value.into_py(py))
+            } else if let Some(value) = n.as_f64() {
+                Ok(value.into_py(py))
             } else {
-                panic!("Unsupported number type");
+                unimplemented!("No support for number of type {n}")
             }
         }
         Value::String(s) => Ok(s.into_py(py)),

--- a/crates/pyluwen/src/lib.rs
+++ b/crates/pyluwen/src/lib.rs
@@ -640,9 +640,13 @@ impl PciChip {
 
     #[new]
     pub fn new(pci_interface: Option<usize>) -> PyResult<Self> {
-        let pci_interface = pci_interface.unwrap();
+        let pci_interface = pci_interface.unwrap_or(0);
 
-        let chip = luwen_ref::ExtendedPciDevice::open(pci_interface).unwrap();
+        let chip = luwen_ref::ExtendedPciDevice::open(pci_interface).map_err(|v| {
+            PyException::new_err(format!(
+                "Could not open chip on pci interface {pci_interface}\n Failed with: {v}"
+            ))
+        })?;
 
         let arch = chip.borrow().device.arch;
 


### PR DESCRIPTION
Removed the unwrap on PciChip::open it will now return an error forwarding the underlying file does not exist error.

Currently waiting on hardware tests to be merged so I can add a test to verify this behvaiour