### PR TITLE
Update tests to use new syseng runners

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -78,7 +78,7 @@ jobs:
           command: test
           args: --no-fail-fast
           
-  hardwre_test_wh:
+  hardware_test_wh:
     name: Hardware Test Suite (WH)
     runs-on: "tt-lab-runners-syseng-n150"
 


### PR DESCRIPTION
We've recently added dedicated infrastructure for luwen and other syseng related projects. Do we want to use these runners for builds?