### PR TITLE
support telemetry buffer offsets > 256 bytes for blackhole

### DIFF
--- a/crates/luwen-if/src/chip/blackhole.rs
+++ b/crates/luwen-if/src/chip/blackhole.rs
@@ -37,7 +37,7 @@ use std::collections::HashMap;
 
 // pub use telemetry_tags::telemetry_tags_to_u32;
 
-fn u32_from_slice(data: &[u8], index: u8) -> u32 {
+fn u32_from_slice(data: &[u8], index: u16) -> u32 {
     let mut output = 0;
     let index = index * 4;
     let data_chunk = &data[index as usize..(index + 4) as usize];
@@ -726,11 +726,11 @@ impl ChipImpl for Blackhole {
 
         // Parse telemetry data
         let mut telemetry_data = super::Telemetry::default();
-        for i in 0..entry_count as u8 {
+        for i in 0..entry_count as u16 {
             let entry = u32_from_slice(&telemetry_tags_data_block, i);
-            let tag = entry & 0xFF;
-            let offset = (entry >> 16) & 0xFF;
-            let data = u32_from_slice(&telem_data_block, offset as u8);
+            let tag = entry & 0xFFFF;
+            let offset = (entry >> 16) & 0xFFFF;
+            let data = u32_from_slice(&telem_data_block, offset as u16);
             // print!("Tag: {} Data: {:#02x}\n", tag, data);
             if let Some(tag) = TelemetryTags::from_u32(tag) {
                 match tag {


### PR DESCRIPTION
blackhole telemetry parsing code casts the telemetry buffer index to a u8, which means that the effective offset of telemetry data is limited to 256 bytes. This means we cannot use an offset greater than 62, as the slicing code will fail with index 63 (63 * 4 + 4 = 256). Use a u16 for the offset to resolve this, and use a u16 for the tag count as well for future expansion.