### PR TITLE
add fan_rpm to blackhole telemetry tags

### DIFF
--- a/crates/luwen-if/src/chip/blackhole.rs
+++ b/crates/luwen-if/src/chip/blackhole.rs
@@ -777,6 +777,7 @@ impl ChipImpl for Blackhole {
                     TelemetryTags::NocTranslation => {
                         telemetry_data.noc_translation_enabled = data != 0
                     }
+                    TelemetryTags::FanRpm => telemetry_data.fan_rpm = data,
                     _ => (),
                 }
             }

--- a/crates/luwen-if/src/chip/blackhole/telemetry_tags.rs
+++ b/crates/luwen-if/src/chip/blackhole/telemetry_tags.rs
@@ -42,4 +42,5 @@ pub enum TelemetryTags {
     EnabledL2Cpu = 37,
     PcieUsage = 38,
     NocTranslation = 40,
+    FanRpm = 41,
 }

--- a/crates/luwen-if/src/chip/mod.rs
+++ b/crates/luwen-if/src/chip/mod.rs
@@ -136,6 +136,7 @@ pub struct Telemetry {
     pub enabled_gddr: u32,
     pub enabled_l2cpu: u32,
     pub enabled_pcie: u32,
+    pub fan_rpm: u32,
 }
 
 impl Telemetry {

--- a/crates/pyluwen/src/lib.rs
+++ b/crates/pyluwen/src/lib.rs
@@ -251,6 +251,8 @@ pub struct Telemetry {
     enabled_l2cpu: u32,
     #[pyo3(get)]
     enabled_pcie: u32,
+    #[pyo3(get)]
+    fan_rpm: u32,
 }
 impl From<luwen_if::chip::Telemetry> for Telemetry {
     fn from(value: luwen_if::chip::Telemetry) -> Self {
@@ -318,6 +320,7 @@ impl From<luwen_if::chip::Telemetry> for Telemetry {
             enabled_gddr: value.enabled_gddr,
             enabled_l2cpu: value.enabled_l2cpu,
             enabled_pcie: value.enabled_pcie,
+            fan_rpm: value.fan_rpm,
         }
     }
 }


### PR DESCRIPTION
Expose fan_rpm telemetry field to luwen. This is needed to add fan speed reporting in tt-smi: https://github.com/tenstorrent/tt-smi/issues/106