### PR TITLE
fix: Correct loop increment logic in ethernet queue reading

### DIFF
--- a/crates/luwen-ref/src/wormhole/ethernet/ethernet_6.rs
+++ b/crates/luwen-ref/src/wormhole/ethernet/ethernet_6.rs
@@ -522,8 +522,8 @@ pub fn print_queue_state<D>(
         let mut j = 0;
         while j < Q_SIZE {
             q_data.push(read32(user_data, rd_addr)?);
-            j += j;
-            rd_addr += rd_addr;
+            j += 4;
+            rd_addr += 4;
         }
     }
 


### PR DESCRIPTION
This was introduced by commit f9f29ee43558 (Fixed clippy lints and compiler warnings), accidentally converting:
	j = j + 4;
to:
	j += j;
instead of:
	j += 4;