### PR TITLE
A couple of TLB code fixes

### DIFF
--- a/crates/ttkmd-if/src/lib.rs
+++ b/crates/ttkmd-if/src/lib.rs
@@ -98,7 +98,6 @@ pub struct BarMapping {
 pub struct TlbAllocation {
     pub id: u32,
     pub uc_mapping: memmap2::MmapMut,
-    pub wc_mapping: memmap2::MmapMut,
     pub size: u64,
 }
 
@@ -558,20 +557,11 @@ impl PciDevice {
         }
         .map_err(|_err| PciError::TlbAllocationError("Failed to map uc buffer".to_string()))?;
 
-        let wc_mapping = unsafe {
-            memmap2::MmapOptions::default()
-                .len(size as usize)
-                .offset(data.output.mmap_offset_wc)
-                .map_mut(self.device_fd.as_raw_fd())
-        }
-        .map_err(|_err| PciError::TlbAllocationError("Failed to map wc buffer".to_string()))?;
-
         match result {
             Ok(rc) => match rc {
                 0 => Ok(TlbAllocation {
                     id: data.output.id,
                     uc_mapping,
-                    wc_mapping,
                     size,
                 }),
                 errno => Err(PciError::IoctlError(nix::errno::Errno::from_i32(errno))),

--- a/crates/ttkmd-if/src/lib.rs
+++ b/crates/ttkmd-if/src/lib.rs
@@ -97,7 +97,7 @@ pub struct BarMapping {
 #[derive(Debug)]
 pub struct TlbAllocation {
     pub id: u32,
-    pub uc_mapping: memmap2::MmapMut,
+    pub uc_mapping: Option<memmap2::MmapMut>,
     pub size: u64,
 }
 
@@ -561,7 +561,7 @@ impl PciDevice {
             Ok(rc) => match rc {
                 0 => Ok(TlbAllocation {
                     id: data.output.id,
-                    uc_mapping,
+                    uc_mapping: Some(uc_mapping),
                     size,
                 }),
                 errno => Err(PciError::IoctlError(nix::errno::Errno::from_i32(errno))),
@@ -570,7 +570,11 @@ impl PciDevice {
         }
     }
 
-    pub fn free_tlb(&self, alloc: &TlbAllocation) -> Result<(), PciError> {
+    pub fn free_tlb(&self, alloc: &mut TlbAllocation) -> Result<(), PciError> {
+        // Explicitly unmap, otherwise the ioctl will return EBUSY
+        if let Some(mmap) = alloc.uc_mapping.take() {
+            drop(mmap);
+        }
         let result = unsafe {
             ioctl::free_tlb(
                 self.device_fd.as_raw_fd(),
@@ -712,7 +716,12 @@ impl PciDevice {
             match index {
                 PossibleTlbAllocation::Allocation(tlb_allocation) => unsafe {
                     Self::memcpy_to_device(
-                        (tlb_allocation.uc_mapping.as_ptr() as *mut u8).byte_add(offset as usize),
+                        (tlb_allocation
+                            .uc_mapping
+                            .as_ref()
+                            .expect("No mapping")
+                            .as_ptr() as *mut u8)
+                            .byte_add(offset as usize),
                         chunk,
                     );
                 },
@@ -749,7 +758,12 @@ impl PciDevice {
                 PossibleTlbAllocation::Allocation(tlb_allocation) => unsafe {
                     Self::memcpy_from_device(
                         chunk,
-                        (tlb_allocation.uc_mapping.as_ptr() as *mut u8).byte_add(offset as usize),
+                        (tlb_allocation
+                            .uc_mapping
+                            .as_ref()
+                            .expect("No mapping")
+                            .as_ptr() as *mut u8)
+                            .byte_add(offset as usize),
                     );
                 },
                 PossibleTlbAllocation::Hardcoded(_index) => {
@@ -780,8 +794,12 @@ impl PciDevice {
         match tlb_index {
             PossibleTlbAllocation::Allocation(tlb_allocation) => self.write32_no_translation(
                 unsafe {
-                    (tlb_allocation.uc_mapping.as_ptr() as *mut u8).byte_add(offset as usize)
-                        as usize
+                    (tlb_allocation
+                        .uc_mapping
+                        .as_ref()
+                        .expect("No mapping")
+                        .as_ptr() as *mut u8)
+                        .byte_add(offset as usize) as usize
                 },
                 data,
             ),
@@ -803,8 +821,12 @@ impl PciDevice {
         match tlb_index {
             PossibleTlbAllocation::Allocation(tlb_allocation) => {
                 self.read32_no_translation(unsafe {
-                    (tlb_allocation.uc_mapping.as_ptr() as *mut u8).byte_add(offset as usize)
-                        as usize
+                    (tlb_allocation
+                        .uc_mapping
+                        .as_ref()
+                        .expect("No mapping")
+                        .as_ptr() as *mut u8)
+                        .byte_add(offset as usize) as usize
                 })
             }
             PossibleTlbAllocation::Hardcoded(_) => self.read32(offset as u32),


### PR DESCRIPTION
The WC mapping is never used in the luwen code (nor exposed to pyluwen), so just remove it for now. It can be added back if needed in the future.

For the UC code, implement proper unmapping of the mmaped region before the ioctl to free the TLB, since otherwise the ioctl will always result in EBUSY due to the existing reference on the resource.