### PR TITLE
Move tlb allocation into free_tlb by move

### DIFF
--- a/crates/ttkmd-if/src/ioctl.rs
+++ b/crates/ttkmd-if/src/ioctl.rs
@@ -299,7 +299,7 @@ pub struct NocTlbConfig {
     pub linked: u8,
     pub static_vc: u8,
     pub reserved0: [u8; 3],
-    pub reserved1: [u8; 2],
+    pub reserved1: [u32; 2],
 }
 
 #[derive(Default)]


### PR DESCRIPTION
Once free_tlb is run, the TlbAllocation isn't usable so allowing Rust to manage the lifetime simplifies the struct definition.

I also took the opportunity to add an mmio tag to the allocation marking if it is safe to use to access registers.