### PR TITLE
blackhole protobufs: trim 0s after the padding from proto_bin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -704,7 +704,7 @@ checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
 name = "luwen"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "bincode",
  "clap",
@@ -728,7 +728,7 @@ dependencies = [
 
 [[package]]
 name = "luwen-if"
-version = "0.6.6"
+version = "0.6.7"
 dependencies = [
  "bincode",
  "bitfield-struct",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "luwen"
-version = "0.7.3"
+version = "0.7.4"
 description = "A high-level interface for safe and efficient access Tenstorrent AI accelerators"
 edition = "2021"
 license = "Apache-2.0"

--- a/crates/luwen-if/Cargo.toml
+++ b/crates/luwen-if/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "luwen-if"
-version = "0.6.6"
+version = "0.6.7"
 description = "Generic interface to Tenstorrent ai accelerators, abstracting the details of communication"
 edition = "2021"
 license = "Apache-2.0"

--- a/crates/luwen-if/src/chip/blackhole/spirom_tables.rs
+++ b/crates/luwen-if/src/chip/blackhole/spirom_tables.rs
@@ -25,6 +25,13 @@ pub fn remove_padding_proto_bin(proto_bin: &[u8]) -> Result<&[u8], Box<dyn std::
     if proto_bin.is_empty() {
         return Err("Input slice is empty".into());
     }
+    // Some FW versions (80.18.0 - 18.5.0) have a bug padding proto_bins to a multiple of 8 bytes
+    // using trailing 0s. Valid encoded protobufs shouldn't have extra 0s after the padding
+    let proto_bin = if proto_bin.len() % 8 == 0 && proto_bin.ends_with(&[0, 0, 0, 0]) {
+        &proto_bin[..proto_bin.len() - 4]
+    } else {
+        proto_bin
+    };
     let last_byte = proto_bin[proto_bin.len() - 1] as usize;
     // Ensure the input slice has enough bytes to remove the padding
     if proto_bin.len() < last_byte + 1 {


### PR DESCRIPTION
In remove_padding_proto_bin, remove four trailing 0s from the proto_bin if present before removing the conventional padding. This only applies if the proto_bin is padded to a multiple of 8 bytes.

The proto_bin padding should be one of (0), (0,1), (0,1,2), or (0,1,2,3). Protobuf encoding on the FW side handles padding to a multiple of 4 bytes using this padding format, but FW versions 80.18.0 - 18.5.0 further pad each boot_fs section to a multiple of 8 bytes using extra 0s.

This fixes the decode_boot_fs_table function (https://github.com/tenstorrent/luwen/issues/72)