### PR TITLE
add TBP to blackhole telemetry tags

### DIFF
--- a/crates/luwen-if/src/chip/blackhole.rs
+++ b/crates/luwen-if/src/chip/blackhole.rs
@@ -778,6 +778,7 @@ impl ChipImpl for Blackhole {
                         telemetry_data.noc_translation_enabled = data != 0
                     }
                     TelemetryTags::FanRpm => telemetry_data.fan_rpm = data,
+                    TelemetryTags::Tbp => telemetry_data.tbp = data,
                     _ => (),
                 }
             }

--- a/crates/luwen-if/src/chip/blackhole/telemetry_tags.rs
+++ b/crates/luwen-if/src/chip/blackhole/telemetry_tags.rs
@@ -43,4 +43,5 @@ pub enum TelemetryTags {
     PcieUsage = 38,
     NocTranslation = 40,
     FanRpm = 41,
+    Tbp = 54,
 }

--- a/crates/luwen-if/src/chip/mod.rs
+++ b/crates/luwen-if/src/chip/mod.rs
@@ -137,6 +137,7 @@ pub struct Telemetry {
     pub enabled_l2cpu: u32,
     pub enabled_pcie: u32,
     pub fan_rpm: u32,
+    pub tbp: u32,
 }
 
 impl Telemetry {

--- a/crates/pyluwen/src/lib.rs
+++ b/crates/pyluwen/src/lib.rs
@@ -253,6 +253,8 @@ pub struct Telemetry {
     enabled_pcie: u32,
     #[pyo3(get)]
     fan_rpm: u32,
+    #[pyo3(get)]
+    tbp: u32,
 }
 impl From<luwen_if::chip::Telemetry> for Telemetry {
     fn from(value: luwen_if::chip::Telemetry) -> Self {
@@ -321,6 +323,7 @@ impl From<luwen_if::chip::Telemetry> for Telemetry {
             enabled_l2cpu: value.enabled_l2cpu,
             enabled_pcie: value.enabled_pcie,
             fan_rpm: value.fan_rpm,
+            tbp: value.tbp,
         }
     }
 }


### PR DESCRIPTION
Expose TBP (total board power) telemetry field to Luwen. This is related to https://github.com/tenstorrent/luwen/issues/73