### PR TITLE
Convert format strings to make clippy 1.88 happy

### DIFF
--- a/app/check_harvesting/src/main.rs
+++ b/app/check_harvesting/src/main.rs
@@ -50,5 +50,5 @@ fn main() {
     output.pop();
     output.pop();
     output.push_str("\n}");
-    print!("{}", output);
+    print!("{output}");
 }

--- a/app/create-ethernet-map/src/lib.rs
+++ b/app/create-ethernet-map/src/lib.rs
@@ -269,7 +269,7 @@ pub fn generate_map(file: impl AsRef<str>) -> Result<(), LuwenError> {
     let file = file.as_ref();
 
     if let Err(_err) = std::fs::write(file, output) {
-        Err(LuwenError::Custom(format!("Failed to write to {}", file)))
+        Err(LuwenError::Custom(format!("Failed to write to {file}")))
     } else {
         Ok(())
     }

--- a/app/reset/src/main.rs
+++ b/app/reset/src/main.rs
@@ -16,7 +16,7 @@ fn link_reset(interface: usize) -> bool {
     let fd = if let Ok(fd) = std::fs::OpenOptions::new()
         .read(true)
         .write(true)
-        .open(format!("/dev/tenstorrent/{}", interface))
+        .open(format!("/dev/tenstorrent/{interface}"))
     {
         fd
     } else {

--- a/crates/luwen-if/build.rs
+++ b/crates/luwen-if/build.rs
@@ -5,8 +5,8 @@ fn try_to_compiled_proto_file_by_name(
     protoc_path: Option<PathBuf>,
     out_dir: &str,
 ) -> Result<(), std::io::Error> {
-    let proto_file = format!("{}.proto", name);
-    let outname = format!("{}/{}.rs", out_dir, name);
+    let proto_file = format!("{name}.proto");
+    let outname = format!("{out_dir}/{name}.rs");
     let mut protoc_build_config = prost_build::Config::new();
     protoc_build_config.out_dir(out_dir);
 
@@ -18,7 +18,7 @@ fn try_to_compiled_proto_file_by_name(
     }
 
     protoc_build_config.compile_protos(&[proto_file], &["bh_spirom_protobufs/"])?;
-    fs::rename(format!("{}/_.rs", out_dir), outname)?;
+    fs::rename(format!("{out_dir}/_.rs"), outname)?;
     Ok(())
 }
 

--- a/crates/luwen-if/src/arc_msg.rs
+++ b/crates/luwen-if/src/arc_msg.rs
@@ -173,7 +173,7 @@ impl ArcMsg {
                 0 => FwType::ArcL2,
                 1 => FwType::FwBundle,
                 2 => FwType::FwBundleSPI,
-                _ => panic!("Unknown FW type {}", arg),
+                _ => panic!("Unknown FW type {arg}"),
             }),
             value => {
                 unimplemented!("Unknown ARC message {:#x}", value)

--- a/crates/luwen-if/src/chip/blackhole.rs
+++ b/crates/luwen-if/src/chip/blackhole.rs
@@ -425,7 +425,7 @@ impl Blackhole {
         // Decode the proto bin and convert it to a HashMap
         let tag_info = self
             .get_boot_fs_tables_spi_read(tag_name)?
-            .ok_or_else(|| format!("Tag '{}' not found in boot FS tables", tag_name))?;
+            .ok_or_else(|| format!("Tag '{tag_name}' not found in boot FS tables"))?;
         let spi_addr = tag_info.1.spi_addr;
         let image_size = tag_info.1.flags.image_size();
 
@@ -448,7 +448,7 @@ impl Blackhole {
                 spirom_tables::flash_info::FlashInfoTable::decode(&*proto_bin)?,
             );
         } else {
-            return Err(format!("Unsupported tag name: {}", tag_name).into());
+            return Err(format!("Unsupported tag name: {tag_name}").into());
         };
         Ok(final_decode_map)
     }
@@ -469,7 +469,7 @@ impl Blackhole {
             spirom_tables::from_hash_map::<spirom_tables::flash_info::FlashInfoTable>(hashmap)
                 .encode_to_vec()
         } else {
-            return Err(format!("Unsupported tag name: {}", tag_name).into());
+            return Err(format!("Unsupported tag name: {tag_name}").into());
         };
         // Pad the proto bin to be a multiple of 4 bytes to fit into the spirom requirements
         let padding = 4 - (proto_bin.len() % 4);
@@ -480,7 +480,7 @@ impl Blackhole {
         // Write the proto bin to the spirom and update the checksums
         let tag_info = self
             .get_boot_fs_tables_spi_read(tag_name)?
-            .ok_or_else(|| format!("Tag '{}' not found in boot FS tables", tag_name))?;
+            .ok_or_else(|| format!("Tag '{tag_name}' not found in boot FS tables"))?;
 
         let mut fd_in_spi = tag_info.1;
         fd_in_spi.flags.set_image_size(proto_bin.len() as u32);
@@ -687,10 +687,7 @@ impl ChipImpl for Blackhole {
         // Check if the address is within CSM memory. Otherwise, it must be invalid
         if !(0x10000000..=0x1007FFFF).contains(&telem_struct_addr) {
             return Err(PlatformError::Generic(
-                format!(
-                    "Invalid Telemetry struct address: 0x{:08x}",
-                    telem_struct_addr
-                ),
+                format!("Invalid Telemetry struct address: 0x{telem_struct_addr:08x}"),
                 BtWrapper::capture(),
             ));
         }

--- a/crates/luwen-if/src/chip/grayskull.rs
+++ b/crates/luwen-if/src/chip/grayskull.rs
@@ -318,8 +318,7 @@ impl ChipImpl for Grayskull {
                                         let false_count = eth_cores.iter().filter(|&&x| !x).count();
                                         return Ok(ChipInitResult::ErrorContinue(
                                             format!(
-                                                "Ethernet training not complete on [{}/16] ports",
-                                                false_count
+                                                "Ethernet training not complete on [{false_count}/16] ports"
                                             ),
                                             backtrace::Backtrace::capture(),
                                         ));
@@ -329,7 +328,7 @@ impl ChipImpl for Grayskull {
                                     PlatformError::AxiError(error) => {
                                         *comms = CommsStatus::CommunicationError(error.to_string());
                                         return Ok(ChipInitResult::ErrorAbort(
-                                            format!("AXI Error: {}", error),
+                                            format!("AXI Error: {error}"),
                                             backtrace::Backtrace::capture(),
                                         ));
                                     }
@@ -343,8 +342,7 @@ impl ChipImpl for Grayskull {
                                     } => {
                                         return Ok(ChipInitResult::ErrorAbort(
                                             format!(
-                                                "expected chip: {}, actual detected chip: {}",
-                                                expected, actual
+                                                "expected chip: {expected}, actual detected chip: {actual}"
                                             ),
                                             backtrace.0,
                                         ))
@@ -362,8 +360,7 @@ impl ChipImpl for Grayskull {
                                             .join(", ");
                                         return Ok(ChipInitResult::ErrorAbort(
                                             format!(
-                                                "expected chip: {}, actual detected chips: {}",
-                                                expected_chips, actual
+                                                "expected chip: {expected_chips}, actual detected chips: {actual}"
                                             ),
                                             backtrace.0,
                                         ));
@@ -463,7 +460,7 @@ impl ChipImpl for Grayskull {
                                 }
                                 // This is an "expected error" but we probably can't recover from it, so we should abort the init.
                                 crate::ArcMsgError::AxiError(error) => {
-                                    return Ok(ChipInitResult::ErrorAbort(format!("Telemetry AXI error: {}; we expected to have communication, but lost it.", error), backtrace::Backtrace::capture()));
+                                    return Ok(ChipInitResult::ErrorAbort(format!("Telemetry AXI error: {error}; we expected to have communication, but lost it."), backtrace::Backtrace::capture()));
                                 }
                             }
 
@@ -472,19 +469,19 @@ impl ChipImpl for Grayskull {
                             }
 
                             // This is an "expected error" but we probably can't recover from it, so we should abort the init.
-                            PlatformError::AxiError(error) => return Ok(ChipInitResult::ErrorAbort(format!("Telemetry AXI error: {}; we expected to have communication, but lost it.", error), backtrace::Backtrace::capture())),
+                            PlatformError::AxiError(error) => return Ok(ChipInitResult::ErrorAbort(format!("Telemetry AXI error: {error}; we expected to have communication, but lost it."), backtrace::Backtrace::capture())),
 
 
 
                             // We don't expect to hit these cases so if we do, we should assume that something went terribly
                             // wrong and abort the init.
                             PlatformError::WrongChipArch {actual, expected, backtrace} => {
-                                return Ok(ChipInitResult::ErrorAbort(format!("Expected chip: {}, actual detected chip: {}", expected, actual), backtrace.0))
+                                return Ok(ChipInitResult::ErrorAbort(format!("Expected chip: {expected}, actual detected chip: {actual}"), backtrace.0))
                             }
 
                             PlatformError::WrongChipArchs {actual, expected, backtrace} => {
                                 let expected_chips = expected.iter().map(|arch| arch.to_string()).collect::<Vec<_>>().join(", ");
-                                return Ok(ChipInitResult::ErrorAbort(format!("Expected chip: {}, actual detected chips: {}", expected_chips, actual), backtrace.0));
+                                return Ok(ChipInitResult::ErrorAbort(format!("Expected chip: {expected_chips}, actual detected chips: {actual}"), backtrace.0));
                             }
 
                             PlatformError::Generic(error, backtrace) => {

--- a/crates/luwen-if/src/chip/init/mod.rs
+++ b/crates/luwen-if/src/chip/init/mod.rs
@@ -74,7 +74,7 @@ pub fn wait_for_init<E>(
                 // but we can continue to initialize other chips (assuming we are allowing failures).
                 if !allow_failure {
                     Err(PlatformError::Generic(
-                        format!("Chip initialization failed: {} \n{}", error, status),
+                        format!("Chip initialization failed: {error} \n{status}"),
                         crate::error::BtWrapper(bt_tracker),
                     ))?;
                 } else {
@@ -88,10 +88,7 @@ pub fn wait_for_init<E>(
             }
             super::ChipInitResult::ErrorAbort(error, bt_tracker) => {
                 Err(PlatformError::Generic(
-                    format!(
-                        "Chip initialization failed (aborted): {} \n{}",
-                        error, status
-                    ),
+                    format!("Chip initialization failed (aborted): {error} \n{status}"),
                     crate::error::BtWrapper(bt_tracker),
                 ))?;
             }
@@ -109,7 +106,7 @@ pub fn wait_for_init<E>(
             .map_err(InitError::CallbackError)?;
             if status.has_error() {
                 Err(PlatformError::Generic(
-                    format!("Chip initialization failed:\n{} ", status),
+                    format!("Chip initialization failed:\n{status} "),
                     crate::error::BtWrapper::capture(),
                 ))?;
             }

--- a/crates/luwen-if/src/chip/mod.rs
+++ b/crates/luwen-if/src/chip/mod.rs
@@ -147,7 +147,7 @@ impl Telemetry {
         let day = (self.wh_fw_date >> 16) & 0xFF;
         let _hour = (self.wh_fw_date >> 8) & 0xFF;
         let _minute = self.wh_fw_date & 0xFF;
-        format!("{:04}-{:02}-{:02}", year, month, day)
+        format!("{year:04}-{month:02}-{day:02}")
     }
 
     /// Return ARC firmware version in MAJOR.MINOR.PATCH format.
@@ -155,7 +155,7 @@ impl Telemetry {
         let major = (self.arc0_fw_version >> 16) & 0xFF;
         let minor = (self.arc0_fw_version >> 8) & 0xFF;
         let patch = self.arc0_fw_version & 0xFF;
-        format!("{}.{}.{}", major, minor, patch)
+        format!("{major}.{minor}.{patch}")
     }
 
     /// Return Ethernet firmware version in MAJOR.MINOR.PATCH format.
@@ -163,7 +163,7 @@ impl Telemetry {
         let major = (self.eth_fw_version >> 16) & 0x0FF;
         let minor = (self.eth_fw_version >> 12) & 0x00F;
         let patch = self.eth_fw_version & 0xFFF;
-        format!("{}.{}.{}", major, minor, patch)
+        format!("{major}.{minor}.{patch}")
     }
 
     /// Return the board serial number as an integer.

--- a/crates/luwen-if/src/chip/wh_ubb.rs
+++ b/crates/luwen-if/src/chip/wh_ubb.rs
@@ -23,11 +23,9 @@ pub fn wh_ubb_ipmi_reset(
     op_mode: &str,
     reset_time: &str,
 ) -> Result<(), String> {
-    let full_command = format!(
-        "sudo ipmitool raw 0x30 0x8B {} {} {} {}",
-        ubb_num, dev_num, op_mode, reset_time
-    );
-    println!("Executing command: {}", full_command);
+    let full_command =
+        format!("sudo ipmitool raw 0x30 0x8B {ubb_num} {dev_num} {op_mode} {reset_time}");
+    println!("Executing command: {full_command}");
 
     let output = Command::new("sudo")
         .arg("ipmitool")
@@ -39,7 +37,7 @@ pub fn wh_ubb_ipmi_reset(
         .arg(op_mode)
         .arg(reset_time)
         .output()
-        .map_err(|e| format!("Failed to execute ipmitool: {}", e))?;
+        .map_err(|e| format!("Failed to execute ipmitool: {e}"))?;
 
     if output.status.success() {
         Ok(())
@@ -65,7 +63,7 @@ pub fn ubb_wait_for_driver_load() {
                 return;
             }
         }
-        println!("Waiting for driver load ... {} seconds", attempts);
+        println!("Waiting for driver load ... {attempts} seconds");
         std::thread::sleep(std::time::Duration::from_secs(1));
         attempts += 1;
     }

--- a/crates/luwen-if/src/chip/wormhole.rs
+++ b/crates/luwen-if/src/chip/wormhole.rs
@@ -451,7 +451,7 @@ impl ChipImpl for Wormhole {
                                     PlatformError::AxiError(error) => {
                                         *comms = CommsStatus::CommunicationError(error.to_string());
                                         return Ok(ChipInitResult::ErrorAbort(
-                                            format!("ARC AXI error: {}", error),
+                                            format!("ARC AXI error: {error}"),
                                             backtrace::Backtrace::capture(),
                                         ));
                                     }
@@ -465,8 +465,7 @@ impl ChipImpl for Wormhole {
                                     } => {
                                         return Ok(ChipInitResult::ErrorAbort(
                                             format!(
-                                                "expected chip: {}, actual detected chip: {}",
-                                                expected, actual
+                                                "expected chip: {expected}, actual detected chip: {actual}"
                                             ),
                                             backtrace.0,
                                         ))
@@ -484,8 +483,7 @@ impl ChipImpl for Wormhole {
                                             .join(", ");
                                         return Ok(ChipInitResult::ErrorAbort(
                                             format!(
-                                                "expected chip: {}, actual detected chips: {}",
-                                                expected_chips, actual
+                                                "expected chip: {expected_chips}, actual detected chips: {actual}"
                                             ),
                                             backtrace.0,
                                         ));
@@ -564,11 +562,11 @@ impl ChipImpl for Wormhole {
                             // This means that ARC hung, we should stop initializing this chip in case
                             // we hit something like a noc hang.
                             PlatformError::ArcMsgError(error) => {
-                                return Ok(ChipInitResult::ErrorContinue(format!("Telemetry ARC message error: {}; we expected to have communication, but lost it.", error), backtrace::Backtrace::capture()));
+                                return Ok(ChipInitResult::ErrorContinue(format!("Telemetry ARC message error: {error}; we expected to have communication, but lost it."), backtrace::Backtrace::capture()));
                             }
 
                             PlatformError::MessageError(error) => {
-                                return Ok(ChipInitResult::ErrorContinue(format!("Telemetry ARC message error: {:?}; we expected to have communication, but lost it.", error), backtrace::Backtrace::capture()));
+                                return Ok(ChipInitResult::ErrorContinue(format!("Telemetry ARC message error: {error:?}; we expected to have communication, but lost it."), backtrace::Backtrace::capture()));
                             }
 
                             // This is an "expected error" but we probably can't recover from it, so we should abort the init.
@@ -577,12 +575,12 @@ impl ChipImpl for Wormhole {
                             // We don't expect to hit these cases so if we do, we should assume that something went terribly
                             // wrong and abort the init.
                             PlatformError::WrongChipArch {actual, expected, backtrace} => {
-                                return Ok(ChipInitResult::ErrorAbort(format!("expected chip: {}, actual detected chip: {}", expected, actual), backtrace.0))
+                                return Ok(ChipInitResult::ErrorAbort(format!("expected chip: {expected}, actual detected chip: {actual}"), backtrace.0))
                             }
 
                             PlatformError::WrongChipArchs {actual, expected, backtrace} => {
                                 let expected_chips = expected.iter().map(|arch| arch.to_string()).collect::<Vec<_>>().join(", ");
-                                return Ok(ChipInitResult::ErrorAbort(format!("expected chip: {}, actual detected chips: {}", expected_chips, actual), backtrace.0));
+                                return Ok(ChipInitResult::ErrorAbort(format!("expected chip: {expected_chips}, actual detected chips: {actual}"), backtrace.0));
                             }
 
                             PlatformError::Generic(error, backtrace) => {
@@ -701,8 +699,7 @@ impl ChipImpl for Wormhole {
                                     let false_count = eth_cores.iter().filter(|&&x| !x).count();
                                     return Ok(ChipInitResult::ErrorContinue(
                                         format!(
-                                            "Ethernet training not complete on [{}/16] ports",
-                                            false_count
+                                            "Ethernet training not complete on [{false_count}/16] ports"
                                         ),
                                         backtrace::Backtrace::capture(),
                                     ));
@@ -719,7 +716,7 @@ impl ChipImpl for Wormhole {
                                 // We don't expect to hit these cases so if we do, we should assume that something went terribly
                                 // wrong and abort the init.
                                 PlatformError::UnsupportedFwVersion { version, required } => {
-                                    return Ok(ChipInitResult::ErrorAbort(format!("Required Ethernet Firmware Version: {}, current version: {:?}", required, version), backtrace::Backtrace::capture()));
+                                    return Ok(ChipInitResult::ErrorAbort(format!("Required Ethernet Firmware Version: {required}, current version: {version:?}"), backtrace::Backtrace::capture()));
                                 }
                                 PlatformError::WrongChipArch {
                                     actual,
@@ -728,9 +725,8 @@ impl ChipImpl for Wormhole {
                                 } => {
                                     return Ok(ChipInitResult::ErrorAbort(
                                         format!(
-                                            "expected chip: {}, actual detected chip: {}",
-                                            expected, actual
-                                        ),
+                                        "expected chip: {expected}, actual detected chip: {actual}"
+                                    ),
                                         backtrace.0,
                                     ))
                                 }
@@ -747,8 +743,7 @@ impl ChipImpl for Wormhole {
                                         .join(", ");
                                     return Ok(ChipInitResult::ErrorAbort(
                                         format!(
-                                            "expected chip: {}, actual detected chips: {}",
-                                            expected_chips, actual
+                                            "expected chip: {expected_chips}, actual detected chips: {actual}"
                                         ),
                                         backtrace.0,
                                     ));

--- a/crates/luwen-if/src/interface.rs
+++ b/crates/luwen-if/src/interface.rs
@@ -82,10 +82,7 @@ impl DeviceInfo {
         let bus = format!("{:02x}", self.bus);
         let slot = format!("{:02x}", self.slot);
         let function = format!("{:01x}", self.function);
-        format!(
-            "/sys/bus/pci/devices/{}:{}:{}.{}/",
-            domain, bus, slot, function
-        )
+        format!("/sys/bus/pci/devices/{domain}:{bus}:{slot}.{function}/")
     }
 
     /// Return link width; valid values of `s` are "current" and "max".

--- a/crates/luwen-ref/src/detect.rs
+++ b/crates/luwen-ref/src/detect.rs
@@ -80,7 +80,7 @@ pub fn detect_chips_options_notui(
 
     let chips = match luwen_if::detect_chips(chips, &mut init_callback, options) {
         Err(InitError::CallbackError(err)) => {
-            eprintln!("Ran into error from status callback;\n{}", err);
+            eprintln!("Ran into error from status callback;\n{err}");
             return Err(luwen_if::error::PlatformError::Generic(
                 "Hit error from status callback".to_string(),
                 luwen_if::error::BtWrapper::capture(),
@@ -217,7 +217,7 @@ pub fn detect_chips_options_tui(
     let chips = match luwen_if::detect_chips(chips, &mut init_callback, options) {
         Err(InitError::CallbackError(err)) => {
             chip_detect_bar
-                .finish_with_message(format!("Ran into error from status callback;\n{}", err));
+                .finish_with_message(format!("Ran into error from status callback;\n{err}"));
             return Err(luwen_if::error::PlatformError::Generic(
                 "Hit error from status callback".to_string(),
                 luwen_if::error::BtWrapper::capture(),

--- a/crates/luwencpp/tests/header_compilation_test.rs
+++ b/crates/luwencpp/tests/header_compilation_test.rs
@@ -25,8 +25,7 @@ fn test_header_compiles() {
     // The header should exist since cargo builds the crate before running tests
     if !header_path.exists() {
         panic!(
-            "Could not find generated luwen.h header file at {:?}. Make sure luwencpp is built.",
-            header_path
+            "Could not find generated luwen.h header file at {header_path:?}. Make sure luwencpp is built."
         );
     }
 
@@ -39,7 +38,7 @@ void test_chip_forward_declaration() {
     luwen::Chip* chip = nullptr;
     luwen::LuwenGlue glue = {};
     chip = luwen::luwen_open(luwen::Arch::WORMHOLE, glue);
-    
+
     if (chip) {
         luwen::chip_telemetry(chip);
         luwen::luwen_close(chip);

--- a/crates/pyluwen/src/lib.rs
+++ b/crates/pyluwen/src/lib.rs
@@ -1075,7 +1075,7 @@ impl PciWormhole {
         Ok(RemoteWormhole(
             self.0
                 .open_remote((rack_x, rack_y, shelf_x, shelf_y))
-                .map_err(|v| PyException::new_err(format!("Could not open remote: {}", v)))?,
+                .map_err(|v| PyException::new_err(format!("Could not open remote: {v}")))?,
         ))
     }
 
@@ -1128,9 +1128,9 @@ impl PciWormhole {
         let value = PciInterface::from_wh(self);
 
         if let Some(value) = value {
-            Ok(value.allocate_dma_buffer(size).map_err(|v| {
-                PyException::new_err(format!("Could not allocate DMA buffer: {}", v))
-            })?)
+            Ok(value
+                .allocate_dma_buffer(size)
+                .map_err(|v| PyException::new_err(format!("Could not allocate DMA buffer: {v}")))?)
         } else {
             Err(PyException::new_err(
                 "Could not get PCI interface for this chip.",
@@ -1160,7 +1160,7 @@ impl PciWormhole {
                     read_threshold,
                     write_threshold,
                 )
-                .map_err(|v| PyException::new_err(format!("Could perform dma config: {}", v)))?)
+                .map_err(|v| PyException::new_err(format!("Could perform dma config: {v}")))?)
         } else {
             Err(PyException::new_err(
                 "Could not get PCI interface for this chip.",
@@ -1180,7 +1180,7 @@ impl PciWormhole {
         if let Some(value) = value {
             Ok(value
                 .dma_transfer_turbo(addr, physical_dma_buffer, size, write)
-                .map_err(|v| PyException::new_err(format!("Could perform dma transfer: {}", v)))?)
+                .map_err(|v| PyException::new_err(format!("Could perform dma transfer: {v}")))?)
         } else {
             Err(PyException::new_err(
                 "Could not get PCI interface for this chip.",
@@ -1333,9 +1333,9 @@ impl PciBlackhole {
         let value = PciInterface::from_bh(self);
 
         if let Some(value) = value {
-            Ok(value.allocate_dma_buffer(size).map_err(|v| {
-                PyException::new_err(format!("Could not allocate DMA buffer: {}", v))
-            })?)
+            Ok(value
+                .allocate_dma_buffer(size)
+                .map_err(|v| PyException::new_err(format!("Could not allocate DMA buffer: {v}")))?)
         } else {
             Err(PyException::new_err(
                 "Could not get PCI interface for this chip.",
@@ -1365,7 +1365,7 @@ impl PciBlackhole {
                     read_threshold,
                     write_threshold,
                 )
-                .map_err(|v| PyException::new_err(format!("Could perform dma config: {}", v)))?)
+                .map_err(|v| PyException::new_err(format!("Could perform dma config: {v}")))?)
         } else {
             Err(PyException::new_err(
                 "Could not get PCI interface for this chip.",
@@ -1385,7 +1385,7 @@ impl PciBlackhole {
         if let Some(value) = value {
             Ok(value
                 .dma_transfer_turbo(addr, physical_dma_buffer, size, write)
-                .map_err(|v| PyException::new_err(format!("Could perform dma transfer: {}", v)))?)
+                .map_err(|v| PyException::new_err(format!("Could perform dma transfer: {v}")))?)
         } else {
             Err(PyException::new_err(
                 "Could not get PCI interface for this chip.",
@@ -1596,8 +1596,7 @@ pub fn detect_chips_fallible(
 
         if !error_interfaces.is_empty() {
             return Err(PyException::new_err(format!(
-                "Could not open TT-PCI device: {:?}; expected one of {:?}",
-                error_interfaces, all_devices
+                "Could not open TT-PCI device: {error_interfaces:?}; expected one of {all_devices:?}"
             )));
         }
 
@@ -1631,7 +1630,7 @@ pub fn detect_chips_fallible(
     let mut converted_chip_filter = Vec::with_capacity(chip_filter.len());
     for filter in chip_filter {
         converted_chip_filter.push(Arch::from_str(&filter).map_err(|value| {
-            PyException::new_err(format!("Could not parse chip arch: {}", value))
+            PyException::new_err(format!("Could not parse chip arch: {value}"))
         })?);
     }
     let options = ChipDetectOptions {

--- a/crates/ttkmd-if/src/lib.rs
+++ b/crates/ttkmd-if/src/lib.rs
@@ -419,8 +419,7 @@ impl PciDevice {
             .read(true)
             .write(false)
             .open(format!(
-                "/sys/bus/pci/devices/{:04x}:{:02x}:{:02x}.{:01x}/config",
-                pci_domain, pci_bus, slot, pci_function
+                "/sys/bus/pci/devices/{pci_domain:04x}:{pci_bus:02x}:{slot:02x}.{pci_function:01x}/config"
             ));
         let config_space = match config_space {
             Ok(file) => file,

--- a/crates/ttkmd-if/src/pci.rs
+++ b/crates/ttkmd-if/src/pci.rs
@@ -17,11 +17,11 @@ pub(crate) fn read_bar0_base(config_space: &std::fs::File) -> u64 {
     match size {
         Ok(size) => {
             if size != std::mem::size_of::<u64>() {
-                panic!("Failed to read BAR0 config space: {}", size);
+                panic!("Failed to read BAR0 config space: {size}");
             }
         }
         Err(err) => {
-            panic!("Failed to read BAR0 config space: {}", err);
+            panic!("Failed to read BAR0 config space: {err}");
         }
     }
 

--- a/src/bin/druken_monkey/main.rs
+++ b/src/bin/druken_monkey/main.rs
@@ -169,8 +169,8 @@ fn compare_and_reset(expected: &dyn Any) {
                 // let bt1 = err.to_string();
                 // let bt2 = platform_error.to_string();
                 // assert_eq!(bt1, bt2);
-                println!("Actual: {:?}", err);
-                println!("Expected: {:?}", platform_error);
+                println!("Actual: {err:?}");
+                println!("Expected: {platform_error:?}");
             }
             _ => panic!("Expected error not found"),
         }
@@ -184,8 +184,8 @@ fn compare_and_reset(expected: &dyn Any) {
                 // let bt1 = err.to_string();
                 // let bt2 = backtrace.to_string();
                 // assert_eq!(bt1, bt2);
-                println!("Actual: {:?}", err);
-                println!("Expected: {:?}", backtrace);
+                println!("Actual: {err:?}");
+                println!("Expected: {backtrace:?}");
             }
             _ => panic!("Expected error not found"),
         }
@@ -291,7 +291,7 @@ fn main() {
                     }
                     Err(panic_info) => {
                         if let Some(s) = panic_info.downcast_ref::<&str>() {
-                            println!("Panic occurred: {}", s);
+                            println!("Panic occurred: {s}");
                         } else {
                             println!("Panic occurred");
                         }

--- a/src/bin/ethernet_benchmark.rs
+++ b/src/bin/ethernet_benchmark.rs
@@ -68,7 +68,7 @@ fn read_write_test(
                 let r = u32::from_le_bytes([r[0], r[1], r[2], r[3]]);
 
                 if r == d {
-                    println!("Match at {}", index)
+                    println!("Match at {index}")
                 }
             }
             panic!("Data mismatch at {index} ({d:x} != {r:x})");

--- a/src/bin/luwen-demo.rs
+++ b/src/bin/luwen-demo.rs
@@ -84,13 +84,13 @@ pub fn main() -> Result<(), LuwenError> {
 
             for (i, d) in data.iter().enumerate() {
                 if *d != (i + 1) as u8 {
-                    panic!("Mismatch at index {}", i);
+                    panic!("Mismatch at index {i}");
                 }
             }
 
             for (i, d) in turbo_data.iter().enumerate() {
                 if *d != (i + 1) as u8 {
-                    panic!("Mismatch at index {}", i);
+                    panic!("Mismatch at index {i}");
                 }
             }
         }

--- a/tests/decode_proto_bin_test.rs
+++ b/tests/decode_proto_bin_test.rs
@@ -36,7 +36,7 @@ mod tests {
             if let Some(bh) = device.as_bh() {
                 // Test decoding the boardcfg table from the boot fs
                 let decode_msg = bh.decode_boot_fs_table("boardcfg");
-                println!("Decoded boardcfg: {:#?}", decode_msg);
+                println!("Decoded boardcfg: {decode_msg:#?}");
 
                 // Verify the decoding was successful
                 assert!(decode_msg.is_ok(), "Failed to decode boardcfg table");
@@ -61,7 +61,7 @@ mod tests {
             if let Some(bh) = device.as_bh() {
                 // Test decoding the flshinfo table from the boot fs
                 let decode_msg = bh.decode_boot_fs_table("flshinfo");
-                println!("Decoded flshinfo: {:#?}", decode_msg);
+                println!("Decoded flshinfo: {decode_msg:#?}");
 
                 // Verify the decoding was successful
                 assert!(decode_msg.is_ok(), "Failed to decode flshinfo table");
@@ -86,7 +86,7 @@ mod tests {
             if let Some(bh) = device.as_bh() {
                 // Test decoding the cmfwcfg table from the boot fs
                 let decode_msg = bh.decode_boot_fs_table("cmfwcfg");
-                println!("Decoded cmfwcfg: {:#?}", decode_msg);
+                println!("Decoded cmfwcfg: {decode_msg:#?}");
 
                 // Verify the decoding was successful
                 assert!(decode_msg.is_ok(), "Failed to decode cmfwcfg table");
@@ -111,7 +111,7 @@ mod tests {
             if let Some(bh) = device.as_bh() {
                 // Test decoding the origcfg table from the boot fs
                 let decode_msg = bh.decode_boot_fs_table("origcfg");
-                println!("Decoded origcfg: {:#?}", decode_msg);
+                println!("Decoded origcfg: {decode_msg:#?}");
                 // There isn't much else to test here -- most boards
                 // don't actually have an origcfg so there's nothing
                 // to validate.

--- a/tests/detect_test.rs
+++ b/tests/detect_test.rs
@@ -45,7 +45,7 @@ mod tests {
 
                     // Test Grayskull-specific functionality
                     let scratch_value = gs.axi_sread32("ARC_RESET.SCRATCH[0]").unwrap();
-                    println!("Grayskull scratch value: {:x}", scratch_value);
+                    println!("Grayskull scratch value: {scratch_value:x}");
 
                     println!(
                         "Grayskull Chip: {:?}, Status: {:?}, Ethernet: {:?}",
@@ -127,7 +127,7 @@ mod tests {
 
                     // Test Blackhole-specific functionality
                     let telemetry = bh.get_telemetry().unwrap();
-                    println!("Blackhole telemetry: {:?}", telemetry);
+                    println!("Blackhole telemetry: {telemetry:?}");
 
                     // Test arc message
                     let result = bh
@@ -140,11 +140,11 @@ mod tests {
                             ..Default::default()
                         })
                         .unwrap();
-                    println!("ARC message result: {:?}", result);
+                    println!("ARC message result: {result:?}");
 
                     // Read scratch register
                     let scratch_value = bh.axi_sread32("arc_ss.reset_unit.SCRATCH_RAM[0]").unwrap();
-                    println!("Blackhole scratch value: {:x}", scratch_value);
+                    println!("Blackhole scratch value: {scratch_value:x}");
 
                     println!(
                         "Blackhole Chip: {:?}, Status: {:?}, Ethernet: {:?}",

--- a/tests/read_write_test.rs
+++ b/tests/read_write_test.rs
@@ -110,8 +110,7 @@ mod tests {
         let readback = fixture.raw_device.read32(fixture.aligned_addr).unwrap();
         assert_eq!(
             readback, 0x0000_faca,
-            "Aligned read/write of 0xfaca failed, got 0x{:x}",
-            readback
+            "Aligned read/write of 0xfaca failed, got 0x{readback:x}"
         );
 
         // Test 2: Aligned write/read with 32-bit pattern
@@ -122,8 +121,7 @@ mod tests {
         let readback = fixture.raw_device.read32(fixture.aligned_addr).unwrap();
         assert_eq!(
             readback, 0xcdcd_cdcd,
-            "Aligned read/write of 0xcdcdcdcd failed, got 0x{:x}",
-            readback
+            "Aligned read/write of 0xcdcdcdcd failed, got 0x{readback:x}"
         );
 
         // Test 3: Aligned write/read at next word boundary
@@ -134,8 +132,7 @@ mod tests {
         let readback = fixture.raw_device.read32(fixture.aligned_addr + 4).unwrap();
         assert_eq!(
             readback, 0xcdcd_cdcd,
-            "Aligned read/write at next word boundary failed, got 0x{:x}",
-            readback
+            "Aligned read/write at next word boundary failed, got 0x{readback:x}"
         );
     }
 
@@ -160,15 +157,13 @@ mod tests {
         let readback = fixture.raw_device.read32(fixture.aligned_addr).unwrap();
         assert_eq!(
             readback, 0xdeadcd,
-            "Unaligned write +1 effect on current word failed, got 0x{:x}",
-            readback
+            "Unaligned write +1 effect on current word failed, got 0x{readback:x}"
         );
 
         let readback = fixture.raw_device.read32(fixture.aligned_addr + 4).unwrap();
         assert_eq!(
             readback, 0xcdcdcd00,
-            "Unaligned write +1 effect on next word failed, got 0x{:x}",
-            readback
+            "Unaligned write +1 effect on next word failed, got 0x{readback:x}"
         );
 
         // Reset test area to known pattern
@@ -184,15 +179,13 @@ mod tests {
         let readback = fixture.raw_device.read32(fixture.aligned_addr).unwrap();
         assert_eq!(
             readback, 0xfecdcdcd,
-            "Unaligned write +3 effect on current word failed, got 0x{:x}",
-            readback
+            "Unaligned write +3 effect on current word failed, got 0x{readback:x}"
         );
 
         let readback = fixture.raw_device.read32(fixture.aligned_addr + 4).unwrap();
         assert_eq!(
             readback, 0xcd000c0f,
-            "Unaligned write +3 effect on next word failed, got 0x{:x}",
-            readback
+            "Unaligned write +3 effect on next word failed, got 0x{readback:x}"
         );
     }
 
@@ -212,8 +205,7 @@ mod tests {
         let readback = fixture.raw_device.read32(fixture.aligned_addr).unwrap();
         assert_eq!(
             readback, 0x01234567,
-            "Sequential pattern write/read failed, got 0x{:x}",
-            readback
+            "Sequential pattern write/read failed, got 0x{readback:x}"
         );
 
         // Write to adjacent word
@@ -224,8 +216,7 @@ mod tests {
         let readback = fixture.raw_device.read32(fixture.aligned_addr + 4).unwrap();
         assert_eq!(
             readback, 0xabcdef,
-            "Sequential pattern write/read at next word failed, got 0x{:x}",
-            readback
+            "Sequential pattern write/read at next word failed, got 0x{readback:x}"
         );
 
         // Test 7: Verify unaligned reads with sequential data
@@ -233,16 +224,14 @@ mod tests {
         let readback = fixture.raw_device.read32(fixture.aligned_addr + 1).unwrap();
         assert_eq!(
             readback, 0xef012345,
-            "Unaligned read +1 with sequential pattern failed, got 0x{:x}",
-            readback
+            "Unaligned read +1 with sequential pattern failed, got 0x{readback:x}"
         );
 
         // Read with +3 byte offset (crosses word boundary)
         let readback = fixture.raw_device.read32(fixture.aligned_addr + 3).unwrap();
         assert_eq!(
             readback, 0xabcdef01,
-            "Unaligned read +3 with sequential pattern failed, got 0x{:x}",
-            readback
+            "Unaligned read +3 with sequential pattern failed, got 0x{readback:x}"
         );
     }
 
@@ -376,8 +365,7 @@ mod tests {
         let reg_readback = fixture.raw_device.read32(fixture.aligned_addr + 1).unwrap();
         assert_eq!(
             reg_readback, 0xef012345,
-            "Register read at +1 doesn't match expected pattern, got 0x{:x}",
-            reg_readback
+            "Register read at +1 doesn't match expected pattern, got 0x{reg_readback:x}"
         );
 
         // Verify unaligned block read at +1 offset

--- a/tests/spi_test.rs
+++ b/tests/spi_test.rs
@@ -39,7 +39,7 @@ mod tests {
                 let mut board_info = [0u8; 8];
                 wh.spi_read(board_info_addr, &mut board_info).unwrap();
                 let board_info_value = u64::from_le_bytes(board_info);
-                println!("Wormhole BOARD_INFO: {:016X}", board_info_value);
+                println!("Wormhole BOARD_INFO: {board_info_value:016X}");
                 assert_ne!(board_info_value, 0, "Board info should not be zero");
 
                 // Test read-modify-write on spare/scratch area
@@ -74,15 +74,14 @@ mod tests {
                 // Verify read-after-write
                 assert_eq!(
                     verify_value, new_value,
-                    "SPI write verification failed: expected {:?}, got {:?}",
-                    new_value, verify_value
+                    "SPI write verification failed: expected {new_value:?}, got {verify_value:?}"
                 );
 
                 // Read wider area to check SPI handling of different sizes
                 let mut wide_value = [0u8; 8];
                 wh.spi_read(spare_addr, &mut wide_value).unwrap();
                 let wide_value_u64 = u64::from_le_bytes(wide_value);
-                println!("Wide read at 0x{:X}: {:016X}", spare_addr, wide_value_u64);
+                println!("Wide read at 0x{spare_addr:X}: {wide_value_u64:016X}");
 
                 // Verify first 2 bytes match our written value
                 assert_eq!(
@@ -113,7 +112,7 @@ mod tests {
                 let mut board_info = [0u8; 8];
                 gs.spi_read(board_info_addr, &mut board_info).unwrap();
                 let board_info_value = u64::from_le_bytes(board_info);
-                println!("Grayskull BOARD_INFO: {:016X}", board_info_value);
+                println!("Grayskull BOARD_INFO: {board_info_value:016X}");
                 assert_ne!(board_info_value, 0, "Board info should not be zero");
 
                 // Test read-modify-write on spare/scratch area
@@ -148,15 +147,14 @@ mod tests {
                 // Verify read-after-write
                 assert_eq!(
                     verify_value, new_value,
-                    "SPI write verification failed: expected {:?}, got {:?}",
-                    new_value, verify_value
+                    "SPI write verification failed: expected {new_value:?}, got {verify_value:?}"
                 );
 
                 // Read wider area to check SPI handling of different sizes
                 let mut wide_value = [0u8; 8];
                 gs.spi_read(spare_addr, &mut wide_value).unwrap();
                 let wide_value_u64 = u64::from_le_bytes(wide_value);
-                println!("Wide read at 0x{:X}: {:016X}", spare_addr, wide_value_u64);
+                println!("Wide read at 0x{spare_addr:X}: {wide_value_u64:016X}");
 
                 // Verify first 2 bytes match our written value
                 assert_eq!(

--- a/tests/telem_test.rs
+++ b/tests/telem_test.rs
@@ -39,10 +39,10 @@ mod tests {
                 // Only test Wormhole chips
                 if let Some(wh) = upgraded_chip.as_wh() {
                     let status = chip.status();
-                    println!("Wormhole chip status: {:?}", status);
+                    println!("Wormhole chip status: {status:?}");
 
                     let eth_status = chip.eth_safe();
-                    println!("Wormhole ethernet status: {:?}", eth_status);
+                    println!("Wormhole ethernet status: {eth_status:?}");
 
                     println!("Testing Wormhole chip");
 
@@ -89,16 +89,16 @@ mod tests {
                 // Only test Grayskull chips
                 if let Some(gs) = upgraded_chip.as_gs() {
                     let status = chip.status();
-                    println!("Grayskull chip status: {:?}", status);
+                    println!("Grayskull chip status: {status:?}");
 
                     let eth_status = chip.eth_safe();
-                    println!("Grayskull ethernet status: {:?}", eth_status);
+                    println!("Grayskull ethernet status: {eth_status:?}");
 
                     println!("Testing Grayskull chip");
 
                     // Read scratch register
                     let scratch_value = gs.axi_sread32("ARC_RESET.SCRATCH[0]").unwrap();
-                    println!("Grayskull scratch value: {:x}", scratch_value);
+                    println!("Grayskull scratch value: {scratch_value:x}");
 
                     // Print chip information
                     println!(
@@ -134,10 +134,10 @@ mod tests {
                 // Only test Blackhole chips
                 if let Some(bh) = upgraded_chip.as_bh() {
                     let status = chip.status();
-                    println!("Blackhole chip status: {:?}", status);
+                    println!("Blackhole chip status: {status:?}");
 
                     let eth_status = chip.eth_safe();
-                    println!("Blackhole ethernet status: {:?}", eth_status);
+                    println!("Blackhole ethernet status: {eth_status:?}");
 
                     println!("Testing Blackhole chip");
 
@@ -145,8 +145,8 @@ mod tests {
                     let telemetry1 = bh.get_telemetry().unwrap();
                     let telemetry2 = bh.get_telemetry().unwrap();
 
-                    println!("Blackhole telemetry: {:?}", telemetry1);
-                    println!("Blackhole telemetry: {:?}", telemetry2);
+                    println!("Blackhole telemetry: {telemetry1:?}");
+                    println!("Blackhole telemetry: {telemetry2:?}");
 
                     // Get subsystem ID
                     if let Some(subsystem) = bh.get_if::<luwen_if::chip::NocInterface>()
@@ -156,7 +156,7 @@ mod tests {
                                 .downcast_ref::<luwen_if::CallbackStorage<luwen_ref::ExtendedPciDeviceWrapper>>()
                         })
                         .map(|v| v.user_data.borrow().device.physical.subsystem_id) {
-                        println!("Blackhole subsystem ID: {:x}", subsystem);
+                        println!("Blackhole subsystem ID: {subsystem:x}");
                         assert_ne!(subsystem, 0, "Subsystem ID should be non-zero");
                     }
 

--- a/tests/telemetry_functional_test.rs
+++ b/tests/telemetry_functional_test.rs
@@ -90,11 +90,10 @@ mod tests {
 
         // Check TDC is within expected range (3-200)
         let tdc = telemetry.tdc & 0xFFFF;
-        println!("TDC reading: {}", tdc);
+        println!("TDC reading: {tdc}");
         assert!(
             (3..=300).contains(&tdc),
-            "Board TDC (temperature) reading is outside of the expected range: {}",
-            tdc
+            "Board TDC (temperature) reading is outside of the expected range: {tdc}"
         );
 
         // Check asic temperature

--- a/tests/test_utils.rs
+++ b/tests/test_utils.rs
@@ -20,7 +20,7 @@ pub fn hardware_available() -> bool {
             true
         }
         Err(e) => {
-            println!("Test SKIPPED: Error detecting chips: {}", e);
+            println!("Test SKIPPED: Error detecting chips: {e}");
             false
         }
     }
@@ -61,7 +61,7 @@ where
             true
         }
         Err(e) => {
-            println!("Test SKIPPED: Error detecting chips: {}", e);
+            println!("Test SKIPPED: Error detecting chips: {e}");
             false
         }
     }

--- a/tests/write_proto_bin_test.rs
+++ b/tests/write_proto_bin_test.rs
@@ -76,7 +76,7 @@ mod tests {
                 // Verify the decoding was successful
                 assert!(decode_msg.is_ok(), "Failed to decode flshinfo table");
                 let mut flshinfo = decode_msg.unwrap();
-                println!("Decoded flshinfo: {:#?}", flshinfo);
+                println!("Decoded flshinfo: {flshinfo:#?}");
 
                 if let Some(date_programmed) = flshinfo.get_mut("date_programmed") {
                     *date_programmed = json!(111111); // Modify the value anc convert to a serde_json Value


### PR DESCRIPTION
Newer versions of clippy prefers that the variables printed by format!() and friends are inline as part of the format string instead of arguments. Adjust the code accordingly.

This was added in rust 1.58, in 2022. So I think we're safe to assume that we'll always have a newer compiler than that (current dependencies seem to require 1.82 or newer).