### PR TITLE
Lower cargo lock version to be compatible with more rustc versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -704,7 +704,7 @@ checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
 name = "luwen"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "bincode",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "luwen"
-version = "0.7.4"
+version = "0.7.5"
 description = "A high-level interface for safe and efficient access Tenstorrent AI accelerators"
 edition = "2021"
 license = "Apache-2.0"


### PR DESCRIPTION
- Lower cargo lock version 4->3 to be compatible with more rustc versions
- chore to uprev luwen