### PR TITLE
Asahi

### DIFF
--- a/.github/workflows/build-pypi-arm64.yml
+++ b/.github/workflows/build-pypi-arm64.yml
@@ -27,10 +27,6 @@ jobs:
         ref: ${{ inputs.ref }}
         fetch-tags: true
         fetch-depth: 0
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
-      with:
-        python-version: ${{ matrix.python-version }}
     - name: Install pypa/build
       run: >-
         python3 -m
@@ -72,10 +68,6 @@ jobs:
         ref: ${{ inputs.ref }}
         fetch-tags: true
         fetch-depth: 0
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
-      with:
-        python-version: ${{ matrix.python-version }}
     - name: Install pypa/build
       run: >-
         python3 -m

--- a/.github/workflows/build-pypi-arm64.yml
+++ b/.github/workflows/build-pypi-arm64.yml
@@ -1,0 +1,103 @@
+name: Build 🐍 📦 wheels
+
+on:
+  workflow_dispatch:
+  workflow_call:
+    inputs:
+      ref:
+        default: ${{ github.ref }}
+        required: false
+        type: string
+
+jobs:
+  # Build non-abi3 wheels for Python 3.8-3.10
+  build-py-version-specific:
+    name: Build version-specific wheels 📦
+    runs-on: self-hosted
+    strategy:
+      matrix:
+        python-version: ["3.10"]
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        ref: ${{ inputs.ref }}
+        fetch-tags: true
+        fetch-depth: 0
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install pypa/build
+      run: >-
+        python3 -m
+        pip install
+        build
+        --user
+    - name: Build wheel for Python ${{ matrix.python-version }}
+      uses: PyO3/maturin-action@v1
+      with:
+        target: aarch64
+        manylinux: 2014
+        args: --release --out dist -m crates/pyluwen/Cargo.toml --interpreter python${{ matrix.python-version }}
+        before-script-linux: |
+          which unzip || apt install unzip || echo "not apt"
+          which unzip || yum install unzip || echo "not yum"
+          which unzip
+          PROTOC=protoc-21.12-linux-aarch_64.zip
+          curl -OL https://github.com/protocolbuffers/protobuf/releases/download/v21.12/$PROTOC
+          unzip $PROTOC -d protoc3
+          mv -v protoc3/bin/* /usr/local/bin/
+          mv -v protoc3/include/* /usr/local/include/
+    - name: Store the wheel
+      uses: actions/upload-artifact@v4
+      with:
+        name: python-package-py${{ matrix.python-version }}
+        path: dist
+
+  # Build abi3 wheel for Python 3.11+
+  build-py-abi3:
+    name: Build abi3 wheel for Python 3.11+ 📦
+    runs-on: local-runner
+    strategy:
+      matrix:
+        python-version: ["3.11", "3.12", "2.13"]
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        ref: ${{ inputs.ref }}
+        fetch-tags: true
+        fetch-depth: 0
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install pypa/build
+      run: >-
+        python3 -m
+        pip install
+        build
+        --user
+    - name: Build abi3 wheel for ${{ matrix.python-version }}
+      uses: PyO3/maturin-action@v1
+      with:
+        target: aarch64
+        manylinux: 2014
+        args: --release --sdist --out dist -m crates/pyluwen/Cargo.toml --features abi3-py311
+        before-script-linux: |
+          which unzip || apt install unzip || echo "not apt"
+          which unzip || yum install unzip || echo "not yum"
+          which unzip
+          PROTOC=protoc-21.12-linux-aarch_64.zip
+          curl -OL https://github.com/protocolbuffers/protobuf/releases/download/v21.12/$PROTOC
+          unzip $PROTOC -d protoc3
+          mv -v protoc3/bin/* /usr/local/bin/
+          mv -v protoc3/include/* /usr/local/include/
+    - name: Store the wheel
+      uses: actions/upload-artifact@v4
+      with:
+        name: python-package-abi3-py${{ matrix.python-version }}
+        path: dist
+
+

--- a/.github/workflows/build-pypi-arm64.yml
+++ b/.github/workflows/build-pypi-arm64.yml
@@ -1,13 +1,16 @@
 name: Build 🐍 📦 wheels
 
 on:
-  workflow_dispatch:
-  workflow_call:
-    inputs:
-      ref:
-        default: ${{ github.ref }}
-        required: false
-        type: string
+  push:
+    branches:
+      - asahi
+#  workflow_dispatch:
+#  workflow_call:
+#    inputs:
+#      ref:
+#        default: ${{ github.ref }}
+#        required: false
+#        type: string
 
 jobs:
   # Build non-abi3 wheels for Python 3.8-3.10

--- a/.github/workflows/build-pypi-arm64.yml
+++ b/.github/workflows/build-pypi-arm64.yml
@@ -57,7 +57,7 @@ jobs:
   # Build abi3 wheel for Python 3.11+
   build-py-abi3:
     name: Build abi3 wheel for Python 3.11+ 📦
-    runs-on: local-runner
+    runs-on: self-hosted
     strategy:
       matrix:
         python-version: ["3.11", "3.12", "2.13"]


### PR DESCRIPTION
Step 2/8 for tenstorrent/tt-metal#18296

It also uses a local runner, that needs to have docker (podman) installed and running and selinux in permissive mode due to exc errors inside of the container.

Python versions in Asahi (Fedora 24) are 3.10, .11, .12, .13 and even pre-release .14. I didn't add 3.14, but did released 3.10 without abi3-py11 feature, and .11, .12 and .13 with this feature.

4 artifacts are now generated.