### PR TITLE
ttkmd: default to strict ordering for NOC TLBs

### DIFF
--- a/crates/ttkmd-if/src/tlb/mod.rs
+++ b/crates/ttkmd-if/src/tlb/mod.rs
@@ -11,8 +11,8 @@ mod wormhole;
 #[repr(u8)]
 pub enum Ordering {
     RELAXED = 0,
-    STRICT = 1,
     #[default]
+    STRICT = 1,
     POSTED = 2,
     PostedStrict = 3,
     UNKNOWN(u8),


### PR DESCRIPTION
Default to using strict ordering for NOC TLBs. This will ensure reads and writes are reliable, at the cost of performance.