### PR TITLE
Fix: next-lockfile-bump parsing issue

### DIFF
--- a/crates/pyluwen/pyproject.toml
+++ b/crates/pyluwen/pyproject.toml
@@ -33,3 +33,6 @@ build-backend = "maturin"
 
 [tool.maturin]
 features = ["pyo3/extension-module"]
+unstable-flags = [
+	"next-lockfile-bump",
+]


### PR DESCRIPTION
Rust seems to have the want to upgrade the Cargo.lock files to version 4, but this presents a delightful problem to everything else not handling version 4 files.  This adds `next-lockfile-bump` to the maturin options to make all work and this works fine with the stock 1.73 and 1.75 rust in Ubuntu 22.04 and 24.04

Clears up #91 as well