### PR TITLE
telemetry: expose blackhole chip limits in telemetry

### DIFF
--- a/crates/luwen-if/src/chip/blackhole.rs
+++ b/crates/luwen-if/src/chip/blackhole.rs
@@ -808,9 +808,13 @@ impl ChipImpl for Blackhole {
                     TelemetryTags::AsicLocation => telemetry_data.asic_location = data,
                     TelemetryTags::BoardPowerLimit => telemetry_data.board_power_limit = data,
                     TelemetryTags::InputPower => telemetry_data.input_power = data,
+                    TelemetryTags::TdcLimitMax => telemetry_data.tdc_limit_max = data,
+                    TelemetryTags::ThmLimitThrottle => telemetry_data.thm_limit_throttle = data,
                     TelemetryTags::ThermTripCount => telemetry_data.therm_trip_count = data,
                     TelemetryTags::AsicIdHigh => telemetry_data.asic_id_high = data,
                     TelemetryTags::AsicIdLow => telemetry_data.asic_id_low = data,
+                    TelemetryTags::AiclkLimitMax => telemetry_data.aiclk_limit_max = data,
+                    TelemetryTags::TdpLimitMax => telemetry_data.tdp_limit_max = data,
                     _ => (),
                 }
             }

--- a/crates/luwen-if/src/chip/blackhole/telemetry_tags.rs
+++ b/crates/luwen-if/src/chip/blackhole/telemetry_tags.rs
@@ -56,7 +56,11 @@ pub enum TelemetryTags {
     AsicLocation = 52,
     BoardPowerLimit = 53,
     InputPower = 54,
+    TdcLimitMax = 55,
+    ThmLimitThrottle = 56,
     ThermTripCount = 60,
     AsicIdHigh = 61,
     AsicIdLow = 62,
+    AiclkLimitMax = 63,
+    TdpLimitMax = 64,
 }

--- a/crates/luwen-if/src/chip/mod.rs
+++ b/crates/luwen-if/src/chip/mod.rs
@@ -150,9 +150,13 @@ pub struct Telemetry {
     pub asic_location: u32,
     pub board_power_limit: u32,
     pub input_power: u32,
+    pub tdc_limit_max: u32,
+    pub thm_limit_throttle: u32,
     pub therm_trip_count: u32,
     pub asic_id_high: u32,
     pub asic_id_low: u32,
+    pub aiclk_limit_max: u32,
+    pub tdp_limit_max: u32,
 }
 
 impl Telemetry {

--- a/crates/pyluwen/src/lib.rs
+++ b/crates/pyluwen/src/lib.rs
@@ -280,11 +280,19 @@ pub struct Telemetry {
     #[pyo3(get)]
     input_power: u32,
     #[pyo3(get)]
+    tdc_limit_max: u32,
+    #[pyo3(get)]
+    thm_limit_throttle: u32,
+    #[pyo3(get)]
     therm_trip_count: u32,
     #[pyo3(get)]
     asic_id_high: u32,
     #[pyo3(get)]
     asic_id_low: u32,
+    #[pyo3(get)]
+    aiclk_limit_max: u32,
+    #[pyo3(get)]
+    tdp_limit_max: u32,
 }
 impl From<luwen_if::chip::Telemetry> for Telemetry {
     fn from(value: luwen_if::chip::Telemetry) -> Self {
@@ -366,9 +374,13 @@ impl From<luwen_if::chip::Telemetry> for Telemetry {
             asic_location: value.asic_location,
             board_power_limit: value.board_power_limit,
             input_power: value.input_power,
+            tdc_limit_max: value.tdc_limit_max,
+            thm_limit_throttle: value.thm_limit_throttle,
             therm_trip_count: value.therm_trip_count,
             asic_id_high: value.asic_id_high,
             asic_id_low: value.asic_id_low,
+            aiclk_limit_max: value.aiclk_limit_max,
+            tdp_limit_max: value.tdp_limit_max,
         }
     }
 }


### PR DESCRIPTION
adds tdc limit, thermal throttle limit, aiclk limit, and tdp limit