### PR TITLE
Serialize tests that interact with hardware

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -411,6 +411,83 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+
+[[package]]
+name = "futures-sink"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+
+[[package]]
+name = "futures-task"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+
+[[package]]
+name = "futures-util"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -716,6 +793,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "serial_test",
  "ttkmd-if",
 ]
 
@@ -1375,10 +1453,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "scc"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46e6f046b7fef48e2660c57ed794263155d713de679057f2d0c169bfc6e756cc"
+dependencies = [
+ "sdd",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sdd"
+version = "3.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
 
 [[package]]
 name = "serde"
@@ -1435,6 +1528,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "serial_test"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b258109f244e1d6891bf1053a55d63a5cd4f8f4c30cf9a1280989f80e7a1fa9"
+dependencies = [
+ "futures",
+ "log",
+ "once_cell",
+ "parking_lot",
+ "scc",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d69265a08751de7844521fd15003ae0a888e035773ba05695c5c759a6f89eef"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1459,6 +1577,12 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "slab"
+version = "0.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
 
 [[package]]
 name = "smallvec"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,9 @@ rand = "0.8.5"
 nom = "7.1.3"
 clap = { version = "4.4.14", features = ["derive"] }
 
+[dev-dependencies]
+serial_test = "3.2.0"
+
 [package.metadata.workspaces]
 independent = true
 

--- a/crates/ttkmd-if/src/lib.rs
+++ b/crates/ttkmd-if/src/lib.rs
@@ -747,6 +747,7 @@ pub fn get_version() -> Option<DriverVersion> {
         .ok()
         .map(|version| driver_version_parse(&version))
 }
+
 #[cfg(test)]
 mod test {
     use super::*;

--- a/tests/detect_test.rs
+++ b/tests/detect_test.rs
@@ -1,5 +1,7 @@
 #![cfg(test)]
 
+use serial_test::serial;
+
 use luwen_if::{chip::HlCommsInterface, ChipImpl};
 
 /// Test chip detection
@@ -20,6 +22,7 @@ use luwen_if::{chip::HlCommsInterface, ChipImpl};
 /// if hardware is not found, the test will be skipped.
 mod test_utils;
 
+#[serial]
 mod tests {
     use super::*;
     use test_utils::hardware_available;

--- a/tests/read_write_test.rs
+++ b/tests/read_write_test.rs
@@ -1,5 +1,7 @@
 #![cfg(test)]
 
+use serial_test::serial;
+
 use luwen_if::{chip::ArcMsgOptions, ArcMsg, ArcMsgOk, ChipImpl, TypedArcMsg};
 use ttkmd_if::PciDevice;
 
@@ -19,6 +21,7 @@ use ttkmd_if::PciDevice;
 ///
 /// The tests will automatically detect if compatible hardware is present;
 /// if hardware is not found, the test will be skipped.
+#[serial]
 mod tests {
     use luwen_if::chip::HlComms;
     use luwen_ref::detect_chips_fallible;

--- a/tests/telem_test.rs
+++ b/tests/telem_test.rs
@@ -1,5 +1,7 @@
 #![cfg(test)]
 
+use serial_test::serial;
+
 use luwen_core::Arch;
 use luwen_if::{chip::HlCommsInterface, ChipImpl};
 
@@ -21,6 +23,7 @@ use luwen_if::{chip::HlCommsInterface, ChipImpl};
 /// if hardware is not found, the test will be skipped.
 mod test_utils;
 
+#[serial]
 mod tests {
     use super::*;
 

--- a/tests/telemetry_functional_test.rs
+++ b/tests/telemetry_functional_test.rs
@@ -1,5 +1,7 @@
 #![cfg(test)]
 
+use serial_test::serial;
+
 use luwen_if::ChipImpl;
 
 /// Functional tests for chip telemetry
@@ -19,6 +21,7 @@ use luwen_if::ChipImpl;
 /// if hardware is not found, the test will be skipped.
 mod test_utils;
 
+#[serial]
 mod tests {
     use std::sync::Mutex;
 

--- a/tests/wh_ubb_reset_test.rs
+++ b/tests/wh_ubb_reset_test.rs
@@ -1,5 +1,7 @@
 #![cfg(test)]
 
+use serial_test::serial;
+
 use luwen_if::chip::wh_ubb;
 
 /// Test utilities for verifying ubb reset ability
@@ -17,6 +19,7 @@ use luwen_if::chip::wh_ubb;
 /// if hardware is not found, the test will be skipped.
 mod test_utils;
 
+#[serial]
 mod tests {
     use super::*;
 


### PR DESCRIPTION
Resolves issues due to non-determinism (race conditions) between testing threads that interact with real hardware by ensuring all such tests are run serially.
