### PR TITLE
fix: rename crates/pyluwen to bind/pyluwen in debian/rules

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -21,7 +21,7 @@ export DH_VERBOSE=3
 		--parallel \
 		--with=python3 \
 		--buildsystem=pybuild \
-		--sourcedirectory=crates/pyluwen
+		--sourcedirectory=bind/pyluwen
 	echo "Done Stage 1"
 
 execute_after_dh_auto_clean:


### PR DESCRIPTION
This didn't get caught in the initial refactor (f709481) because this file is in .gitignore.