### PR TITLE
Add version_bump_type input param to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,16 @@ run-name: Create Release
 
 on:
   workflow_dispatch:
+    inputs:
+      version_bump_type:
+        description: 'Version bump type'
+        required: true
+        default: 'patch'
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
   workflow_call:
 
 jobs:
@@ -88,7 +98,7 @@ jobs:
           echo "luwen_version=${luwen_ver}"
           echo "luwen_version=${luwen_ver}" >> "$GITHUB_OUTPUT"
       - name: Bump the version
-        run: cargo ws version patch --allow-branch ${{ needs.tempbranch.outputs.rc_ref }} --no-git-tag --message "Cargo Release %v" -y
+        run: cargo ws version ${{ github.event.inputs.version_bump_type }} --allow-branch ${{ needs.tempbranch.outputs.rc_ref }} --no-git-tag --message "Cargo Release %v" -y
       - name: What NEW Version?
         id: new-luwen-version
         run: |


### PR DESCRIPTION
Upon release, allows a choice of which version to bump: patch, minor, major.

Previously it was hardcoded to patch.