### PR TITLE
Update pyo3 to 0.27

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1241,9 +1241,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.22.6"
+version = "0.23.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f402062616ab18202ae8319da13fa4279883a2b8a9d9f83f20dbade813ce1884"
+checksum = "7778bffd85cf38175ac1f545509665d0b9b92a198ca7941f131f85f7a4f9a872"
 dependencies = [
  "cfg-if",
  "indoc",
@@ -1260,9 +1260,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.22.6"
+version = "0.23.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b14b5775b5ff446dd1056212d778012cbe8a0fbffd368029fd9e25b514479c38"
+checksum = "94f6cbe86ef3bf18998d9df6e0f3fc1050a8c5efa409bf712e661a4366e010fb"
 dependencies = [
  "once_cell",
  "target-lexicon",
@@ -1270,9 +1270,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.22.6"
+version = "0.23.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ab5bcf04a2cdcbb50c7d6105de943f543f9ed92af55818fd17b660390fc8636"
+checksum = "e9f1b4c431c0bb1c8fb0a338709859eed0d030ff6daa34368d3b152a63dfdd8d"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -1280,9 +1280,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.22.6"
+version = "0.23.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fd24d897903a9e6d80b968368a34e1525aeb719d568dba8b3d4bfa5dc67d453"
+checksum = "fbc2201328f63c4710f68abdf653c89d8dbc2858b88c5d88b0ff38a75288a9da"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -1292,9 +1292,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.22.6"
+version = "0.23.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36c011a03ba1e50152b4b394b479826cad97e7a21eb52df179cd91ac411cbfbe"
+checksum = "fca6726ad0f3da9c9de093d6f116a93c1a38e417ed73bf138472cf4064f72028"
 dependencies = [
  "heck",
  "proc-macro2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -159,7 +159,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "befbfd072a8e81c02f8c507aefce431fe5e7d051f83d48a23ffc9b9fe5a11799"
 dependencies = [
  "clap",
- "heck 0.5.0",
+ "heck",
  "indexmap",
  "log",
  "proc-macro2",
@@ -228,7 +228,7 @@ version = "4.5.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef4f52386a59ca4c860f7393bcf8abd8dfd91ecccc0f774635ff68e92eeef491"
 dependencies = [
- "heck 0.5.0",
+ "heck",
  "proc-macro2",
  "quote",
  "syn",
@@ -541,12 +541,6 @@ name = "hashbrown"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
-
-[[package]]
-name = "heck"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "heck"
@@ -1194,7 +1188,7 @@ version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
- "heck 0.5.0",
+ "heck",
  "itertools",
  "log",
  "multimap",
@@ -1247,16 +1241,16 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.21.2"
+version = "0.22.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e00b96a521718e08e03b1a622f01c8a8deb50719335de3f60b3b3950f069d8"
+checksum = "f402062616ab18202ae8319da13fa4279883a2b8a9d9f83f20dbade813ce1884"
 dependencies = [
  "cfg-if",
  "indoc",
  "inventory",
  "libc",
  "memoffset 0.9.1",
- "parking_lot",
+ "once_cell",
  "portable-atomic",
  "pyo3-build-config",
  "pyo3-ffi",
@@ -1266,9 +1260,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.21.2"
+version = "0.22.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7883df5835fafdad87c0d888b266c8ec0f4c9ca48a5bed6bbb592e8dedee1b50"
+checksum = "b14b5775b5ff446dd1056212d778012cbe8a0fbffd368029fd9e25b514479c38"
 dependencies = [
  "once_cell",
  "target-lexicon",
@@ -1276,9 +1270,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.21.2"
+version = "0.22.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01be5843dc60b916ab4dad1dca6d20b9b4e6ddc8e15f50c47fe6d85f1fb97403"
+checksum = "9ab5bcf04a2cdcbb50c7d6105de943f543f9ed92af55818fd17b660390fc8636"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -1286,9 +1280,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.21.2"
+version = "0.22.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77b34069fc0682e11b31dbd10321cbf94808394c56fd996796ce45217dfac53c"
+checksum = "0fd24d897903a9e6d80b968368a34e1525aeb719d568dba8b3d4bfa5dc67d453"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -1298,11 +1292,11 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.21.2"
+version = "0.22.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08260721f32db5e1a5beae69a55553f56b99bd0e1c3e6e0a5e8851a9d0f5a85c"
+checksum = "36c011a03ba1e50152b4b394b479826cad97e7a21eb52df179cd91ac411cbfbe"
 dependencies = [
- "heck 0.4.1",
+ "heck",
  "proc-macro2",
  "pyo3-build-config",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1241,11 +1241,10 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.23.5"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7778bffd85cf38175ac1f545509665d0b9b92a198ca7941f131f85f7a4f9a872"
+checksum = "7ba0117f4212101ee6544044dae45abe1083d30ce7b29c4b5cbdfa2354e07383"
 dependencies = [
- "cfg-if",
  "indoc",
  "inventory",
  "libc",
@@ -1260,19 +1259,18 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.23.5"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94f6cbe86ef3bf18998d9df6e0f3fc1050a8c5efa409bf712e661a4366e010fb"
+checksum = "4fc6ddaf24947d12a9aa31ac65431fb1b851b8f4365426e182901eabfb87df5f"
 dependencies = [
- "once_cell",
  "target-lexicon",
 ]
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.23.5"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9f1b4c431c0bb1c8fb0a338709859eed0d030ff6daa34368d3b152a63dfdd8d"
+checksum = "025474d3928738efb38ac36d4744a74a400c901c7596199e20e45d98eb194105"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -1280,9 +1278,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.23.5"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbc2201328f63c4710f68abdf653c89d8dbc2858b88c5d88b0ff38a75288a9da"
+checksum = "2e64eb489f22fe1c95911b77c44cc41e7c19f3082fc81cce90f657cdc42ffded"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -1292,9 +1290,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.23.5"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fca6726ad0f3da9c9de093d6f116a93c1a38e417ed73bf138472cf4064f72028"
+checksum = "100246c0ecf400b475341b8455a9213344569af29a3c841d29270e53102e0fcf"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -1670,9 +1668,9 @@ dependencies = [
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.16"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
+checksum = "b1dd07eb858a2067e2f3c7155d54e929265c264e6f37efe3ee7a8d1b5a1dd0ba"
 
 [[package]]
 name = "tempfile"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -96,7 +96,7 @@ checksum = "adc0846593a56638b74e136a45610f9934c052e14761bebca6b092d5522599e3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn",
 ]
 
 [[package]]
@@ -143,7 +143,7 @@ checksum = "441473f2b4b0459a68628c744bc61d23e730fb00128b841d30fa4bb3972257e4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn",
 ]
 
 [[package]]
@@ -159,14 +159,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "befbfd072a8e81c02f8c507aefce431fe5e7d051f83d48a23ffc9b9fe5a11799"
 dependencies = [
  "clap",
- "heck",
+ "heck 0.5.0",
  "indexmap",
  "log",
  "proc-macro2",
  "quote",
  "serde",
  "serde_json",
- "syn 2.0.104",
+ "syn",
  "tempfile",
  "toml",
 ]
@@ -228,10 +228,10 @@ version = "4.5.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef4f52386a59ca4c860f7393bcf8abd8dfd91ecccc0f774635ff68e92eeef491"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn",
 ]
 
 [[package]]
@@ -334,7 +334,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn",
 ]
 
 [[package]]
@@ -544,6 +544,12 @@ checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
 
 [[package]]
 name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
+name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
@@ -678,7 +684,7 @@ checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn",
 ]
 
 [[package]]
@@ -727,9 +733,12 @@ dependencies = [
 
 [[package]]
 name = "indoc"
-version = "1.0.9"
+version = "2.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa799dd5ed20a7e349f3b4639aa80d74549c81716d9ec4f994c9b5815598306"
+checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
+dependencies = [
+ "rustversion",
+]
 
 [[package]]
 name = "inventory"
@@ -978,7 +987,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn",
 ]
 
 [[package]]
@@ -1093,7 +1102,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff24dfcda44452b9816fff4cd4227e1bb73ff5a2f1bc1105aa92fb8565ce44d2"
 dependencies = [
  "proc-macro2",
- "syn 2.0.104",
+ "syn",
 ]
 
 [[package]]
@@ -1185,7 +1194,7 @@ version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "itertools",
  "log",
  "multimap",
@@ -1195,7 +1204,7 @@ dependencies = [
  "prost",
  "prost-types",
  "regex",
- "syn 2.0.104",
+ "syn",
  "tempfile",
 ]
 
@@ -1209,7 +1218,7 @@ dependencies = [
  "itertools",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn",
 ]
 
 [[package]]
@@ -1238,9 +1247,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.19.2"
+version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e681a6cfdc4adcc93b4d3cf993749a4552018ee0a9b65fc0ccfad74352c72a38"
+checksum = "a5e00b96a521718e08e03b1a622f01c8a8deb50719335de3f60b3b3950f069d8"
 dependencies = [
  "cfg-if",
  "indoc",
@@ -1248,6 +1257,7 @@ dependencies = [
  "libc",
  "memoffset 0.9.1",
  "parking_lot",
+ "portable-atomic",
  "pyo3-build-config",
  "pyo3-ffi",
  "pyo3-macros",
@@ -1256,9 +1266,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.19.2"
+version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "076c73d0bc438f7a4ef6fdd0c3bb4732149136abd952b110ac93e4edb13a6ba5"
+checksum = "7883df5835fafdad87c0d888b266c8ec0f4c9ca48a5bed6bbb592e8dedee1b50"
 dependencies = [
  "once_cell",
  "target-lexicon",
@@ -1266,9 +1276,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.19.2"
+version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e53cee42e77ebe256066ba8aa77eff722b3bb91f3419177cf4cd0f304d3284d9"
+checksum = "01be5843dc60b916ab4dad1dca6d20b9b4e6ddc8e15f50c47fe6d85f1fb97403"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -1276,25 +1286,27 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.19.2"
+version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfeb4c99597e136528c6dd7d5e3de5434d1ceaf487436a3f03b2d56b6fc9efd1"
+checksum = "77b34069fc0682e11b31dbd10321cbf94808394c56fd996796ce45217dfac53c"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
  "quote",
- "syn 1.0.109",
+ "syn",
 ]
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.19.2"
+version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "947dc12175c254889edc0c02e399476c2f652b4b9ebd123aa655c224de259536"
+checksum = "08260721f32db5e1a5beae69a55553f56b99bd0e1c3e6e0a5e8851a9d0f5a85c"
 dependencies = [
+ "heck 0.4.1",
  "proc-macro2",
+ "pyo3-build-config",
  "quote",
- "syn 1.0.109",
+ "syn",
 ]
 
 [[package]]
@@ -1419,7 +1431,7 @@ dependencies = [
  "quote",
  "rust-embed-utils",
  "shellexpand",
- "syn 2.0.104",
+ "syn",
  "walkdir",
 ]
 
@@ -1528,7 +1540,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn",
 ]
 
 [[package]]
@@ -1587,7 +1599,7 @@ checksum = "5d69265a08751de7844521fd15003ae0a888e035773ba05695c5c759a6f89eef"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn",
 ]
 
 [[package]]
@@ -1642,17 +1654,6 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "1.0.109"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
-
-[[package]]
-name = "syn"
 version = "2.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
@@ -1670,7 +1671,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn",
 ]
 
 [[package]]
@@ -1718,7 +1719,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn",
 ]
 
 [[package]]
@@ -1729,7 +1730,7 @@ checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn",
 ]
 
 [[package]]
@@ -1844,7 +1845,7 @@ checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn",
 ]
 
 [[package]]
@@ -1876,9 +1877,9 @@ checksum = "4a1a07cc7db3810833284e8d372ccdc6da29741639ecc70c9ec107df0fa6154c"
 
 [[package]]
 name = "unindent"
-version = "0.1.11"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1766d682d402817b5ac4490b3c3002d91dfa0d22812f341609f97b08757359c"
+checksum = "7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3"
 
 [[package]]
 name = "unsafe-libyaml"
@@ -1967,7 +1968,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn",
  "wasm-bindgen-shared",
 ]
 
@@ -1989,7 +1990,7 @@ checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -2288,7 +2289,7 @@ checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn",
  "synstructure",
 ]
 
@@ -2309,7 +2310,7 @@ checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn",
 ]
 
 [[package]]
@@ -2329,7 +2330,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn",
  "synstructure",
 ]
 
@@ -2352,5 +2353,5 @@ checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1241,9 +1241,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.26.0"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ba0117f4212101ee6544044dae45abe1083d30ce7b29c4b5cbdfa2354e07383"
+checksum = "ab53c047fcd1a1d2a8820fe84f05d6be69e9526be40cb03b73f86b6b03e6d87d"
 dependencies = [
  "indoc",
  "inventory",
@@ -1259,18 +1259,18 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.26.0"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fc6ddaf24947d12a9aa31ac65431fb1b851b8f4365426e182901eabfb87df5f"
+checksum = "b455933107de8642b4487ed26d912c2d899dec6114884214a0b3bb3be9261ea6"
 dependencies = [
  "target-lexicon",
 ]
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.26.0"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "025474d3928738efb38ac36d4744a74a400c901c7596199e20e45d98eb194105"
+checksum = "1c85c9cbfaddf651b1221594209aed57e9e5cff63c4d11d1feead529b872a089"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -1278,9 +1278,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.26.0"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e64eb489f22fe1c95911b77c44cc41e7c19f3082fc81cce90f657cdc42ffded"
+checksum = "0a5b10c9bf9888125d917fb4d2ca2d25c8df94c7ab5a52e13313a07e050a3b02"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -1290,9 +1290,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.26.0"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "100246c0ecf400b475341b8455a9213344569af29a3c841d29270e53102e0fcf"
+checksum = "03b51720d314836e53327f5871d4c0cfb4fb37cc2c4a11cc71907a86342c40f9"
 dependencies = [
  "heck",
  "proc-macro2",

--- a/bind/pyluwen/Cargo.toml
+++ b/bind/pyluwen/Cargo.toml
@@ -26,7 +26,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 luwen = { workspace = true }
-pyo3 = { version = "0.19.2", features = ["extension-module", "multiple-pymethods"] }
+pyo3 = { version = "0.21", features = ["extension-module", "multiple-pymethods"] }
 serde_json = { workspace = true }
 
 [features]

--- a/bind/pyluwen/Cargo.toml
+++ b/bind/pyluwen/Cargo.toml
@@ -26,7 +26,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 luwen = { workspace = true }
-pyo3 = { version = "0.21", features = ["extension-module", "multiple-pymethods"] }
+pyo3 = { version = "0.22", features = ["extension-module", "multiple-pymethods"] }
 serde_json = { workspace = true }
 
 [features]

--- a/bind/pyluwen/Cargo.toml
+++ b/bind/pyluwen/Cargo.toml
@@ -26,7 +26,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 luwen = { workspace = true }
-pyo3 = { version = "0.23", features = ["extension-module", "multiple-pymethods"] }
+pyo3 = { version = "0.26", features = ["extension-module", "multiple-pymethods"] }
 serde_json = { workspace = true }
 
 [features]

--- a/bind/pyluwen/Cargo.toml
+++ b/bind/pyluwen/Cargo.toml
@@ -26,7 +26,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 luwen = { workspace = true }
-pyo3 = { version = "0.22", features = ["extension-module", "multiple-pymethods"] }
+pyo3 = { version = "0.23", features = ["extension-module", "multiple-pymethods"] }
 serde_json = { workspace = true }
 
 [features]

--- a/bind/pyluwen/Cargo.toml
+++ b/bind/pyluwen/Cargo.toml
@@ -26,7 +26,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 luwen = { workspace = true }
-pyo3 = { version = "0.26", features = ["extension-module", "multiple-pymethods"] }
+pyo3 = { version = "0.27", features = ["extension-module", "multiple-pymethods"] }
 serde_json = { workspace = true }
 
 [features]

--- a/bind/pyluwen/src/lib.rs
+++ b/bind/pyluwen/src/lib.rs
@@ -1862,13 +1862,13 @@ fn pyobject_to_serde_json_value(_py: Python, obj: Bound<'_, PyAny>) -> PyResult<
         )?))
     } else if let Ok(s) = obj.extract::<String>() {
         Ok(Value::String(s))
-    } else if let Ok(list) = obj.downcast::<PyList>() {
+    } else if let Ok(list) = obj.cast::<PyList>() {
         let mut array = Vec::new();
         for item in list {
             array.push(pyobject_to_serde_json_value(_py, item)?);
         }
         Ok(Value::Array(array))
-    } else if let Ok(dict) = obj.downcast::<PyDict>() {
+    } else if let Ok(dict) = obj.cast::<PyDict>() {
         let mut map = serde_json::Map::new();
         for (key, value) in dict {
             let key: String = key.extract()?;

--- a/bind/pyluwen/src/lib.rs
+++ b/bind/pyluwen/src/lib.rs
@@ -681,6 +681,7 @@ impl PciChip {
     }
 
     #[new]
+    #[pyo3(signature = (pci_interface = None))]
     pub fn new(pci_interface: Option<usize>) -> PyResult<Self> {
         let pci_interface = pci_interface.unwrap_or(0);
 
@@ -1021,6 +1022,7 @@ impl From<luwen::api::EthAddr> for EthAddr {
 
 #[pymethods]
 impl PciWormhole {
+    #[pyo3(signature = (rack_x=None, rack_y=None, shelf_x=None, shelf_y=None))]
     pub fn open_remote(
         &self,
         rack_x: Option<u8>,

--- a/bind/pyluwen/src/lib.rs
+++ b/bind/pyluwen/src/lib.rs
@@ -397,7 +397,7 @@ macro_rules! common_chip_comms_impls {
                 addr: u64,
                 data: pyo3::buffer::PyBuffer<u8>,
             ) -> PyResult<()> {
-                Python::with_gil(|_py| {
+                Python::attach(|_py| {
                     let ptr: *mut u8 = data.buf_ptr().cast();
                     let len = data.len_bytes();
 
@@ -425,7 +425,7 @@ macro_rules! common_chip_comms_impls {
                 addr: u64,
                 data: pyo3::buffer::PyBuffer<u8>,
             ) -> PyResult<()> {
-                Python::with_gil(|_py| {
+                Python::attach(|_py| {
                     let ptr: *mut u8 = data.buf_ptr().cast();
                     let len = data.len_bytes();
 
@@ -457,7 +457,7 @@ macro_rules! common_chip_comms_impls {
                 addr: u64,
                 data: pyo3::buffer::PyBuffer<u8>,
             ) -> PyResult<()> {
-                Python::with_gil(|_py| {
+                Python::attach(|_py| {
                     let ptr: *mut u8 = data.buf_ptr().cast();
                     let len = data.len_bytes();
 
@@ -522,7 +522,7 @@ macro_rules! common_chip_comms_impls {
                 addr: u64,
                 data: pyo3::buffer::PyBuffer<u8>,
             ) -> PyResult<()> {
-                Python::with_gil(|_py| {
+                Python::attach(|_py| {
                     let ptr: *mut u8 = data.buf_ptr().cast();
                     let len = data.len_bytes();
 
@@ -543,7 +543,7 @@ macro_rules! common_chip_comms_impls {
             }
 
             pub fn axi_read(&self, addr: u64, data: pyo3::buffer::PyBuffer<u8>) -> PyResult<()> {
-                Python::with_gil(|_py| {
+                Python::attach(|_py| {
                     let ptr: *mut u8 = data.buf_ptr().cast();
                     let len = data.len_bytes();
 
@@ -564,7 +564,7 @@ macro_rules! common_chip_comms_impls {
             }
 
             pub fn axi_write(&self, addr: u64, data: pyo3::buffer::PyBuffer<u8>) -> PyResult<()> {
-                Python::with_gil(|_py| {
+                Python::attach(|_py| {
                     let ptr: *mut u8 = data.buf_ptr().cast();
                     let len = data.len_bytes();
 
@@ -706,7 +706,7 @@ impl PciChip {
     }
 
     #[pyo3(signature = (callback = None))]
-    pub fn init(&mut self, callback: Option<PyObject>) -> PyResult<()> {
+    pub fn init(&mut self, callback: Option<Py<PyAny>>) -> PyResult<()> {
         #[allow(clippy::type_complexity)]
         let mut callback: Box<
             dyn FnMut(luwen::api::chip::ChipDetectState) -> Result<(), PyErr>,
@@ -721,7 +721,7 @@ impl PciChip {
                     >(status)
                 };
                 if let Err(err) =
-                    Python::with_gil(|py| callback.call1(py, (PyChipDetectState(status),)))
+                    Python::attach(|py| callback.call1(py, (PyChipDetectState(status),)))
                 {
                     Err(err)
                 } else {
@@ -729,7 +729,7 @@ impl PciChip {
                 }
             })
         } else {
-            Box::new(|_| Python::with_gil(|py| py.check_signals()))
+            Box::new(|_| Python::attach(|py| py.check_signals()))
         };
 
         match wait_for_init(&mut self.0, &mut callback, false, false) {
@@ -1169,7 +1169,7 @@ impl PciWormhole {
     }
 
     pub fn spi_read(&self, addr: u32, data: pyo3::buffer::PyBuffer<u8>) -> PyResult<()> {
-        Python::with_gil(|_py| {
+        Python::attach(|_py| {
             let ptr: *mut u8 = data.buf_ptr().cast();
             let len = data.len_bytes();
 
@@ -1181,7 +1181,7 @@ impl PciWormhole {
     }
 
     pub fn spi_write(&self, addr: u32, data: pyo3::buffer::PyBuffer<u8>) -> PyResult<()> {
-        Python::with_gil(|_py| {
+        Python::attach(|_py| {
             let ptr: *mut u8 = data.buf_ptr().cast();
             let len = data.len_bytes();
 
@@ -1234,7 +1234,7 @@ common_chip_comms_impls!(RemoteWormhole);
 
 impl RemoteWormhole {
     pub fn spi_read(&self, addr: u32, data: pyo3::buffer::PyBuffer<u8>) -> PyResult<()> {
-        Python::with_gil(|_py| {
+        Python::attach(|_py| {
             let ptr: *mut u8 = data.buf_ptr().cast();
             let len = data.len_bytes();
 
@@ -1246,7 +1246,7 @@ impl RemoteWormhole {
     }
 
     pub fn spi_write(&self, addr: u32, data: pyo3::buffer::PyBuffer<u8>) -> PyResult<()> {
-        Python::with_gil(|_py| {
+        Python::attach(|_py| {
             let ptr: *mut u8 = data.buf_ptr().cast();
             let len = data.len_bytes();
 
@@ -1399,7 +1399,7 @@ impl PciBlackhole {
     }
 
     pub fn spi_read(&self, addr: u32, data: pyo3::buffer::PyBuffer<u8>) -> PyResult<()> {
-        Python::with_gil(|_py| {
+        Python::attach(|_py| {
             let ptr: *mut u8 = data.buf_ptr().cast();
             let len = data.len_bytes();
 
@@ -1411,7 +1411,7 @@ impl PciBlackhole {
     }
 
     pub fn spi_write(&self, addr: u32, data: pyo3::buffer::PyBuffer<u8>) -> PyResult<()> {
-        Python::with_gil(|_py| {
+        Python::attach(|_py| {
             let ptr: *mut u8 = data.buf_ptr().cast();
             let len = data.len_bytes();
 
@@ -1431,7 +1431,7 @@ impl PciBlackhole {
 
     pub fn decode_boot_fs_table(&self, tag_name: &str) -> PyResult<Py<PyDict>> {
         // Deserialize the boot fs table given the tag name and return it as a pydict with the correct types
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let result = self
                 .0
                 .decode_boot_fs_table(tag_name)
@@ -1440,7 +1440,7 @@ impl PciBlackhole {
             // Convert the HashMap<String, Value> to a pydict
             for (key, value) in result {
                 let py_key = key.into_pyobject(py)?;
-                let py_value: PyObject = serde_json_value_to_pyobject(py, &value)?;
+                let py_value: Py<PyAny> = serde_json_value_to_pyobject(py, &value)?;
                 py_dict.set_item(py_key, py_value)?;
             }
             Ok(py_dict.into())
@@ -1580,7 +1580,7 @@ impl UninitPciChip {
         let chip = self
             .chip
             .clone()
-            .init(&mut |_| Python::with_gil(|py| py.check_signals()));
+            .init(&mut |_| Python::attach(|py| py.check_signals()));
         match chip {
             Ok(chip) => Ok(PciChip(chip)),
             Err(InitError::PlatformError(err)) => Err(PyException::new_err(err.to_string())),
@@ -1628,7 +1628,7 @@ pub fn detect_chips_fallible(
     continue_on_failure: bool,
     chip_filter: Option<Vec<String>>,
     noc_safe: bool,
-    callback: Option<PyObject>,
+    callback: Option<Py<PyAny>>,
 ) -> PyResult<Vec<UninitPciChip>> {
     let interfaces = interfaces.unwrap_or_default();
 
@@ -1702,7 +1702,7 @@ pub fn detect_chips_fallible(
                     >(status)
                 };
                 if let Err(err) =
-                    Python::with_gil(|py| callback.call1(py, (PyChipDetectState(status),)))
+                    Python::attach(|py| callback.call1(py, (PyChipDetectState(status),)))
                 {
                     Err(err)
                 } else {
@@ -1710,7 +1710,7 @@ pub fn detect_chips_fallible(
                 }
             })
         } else {
-            Box::new(|_| Python::with_gil(|py| py.check_signals()))
+            Box::new(|_| Python::attach(|py| py.check_signals()))
         };
     let mut chips = match luwen::api::detect_chips(root_chips, &mut callback, options) {
         Ok(chips) => chips,
@@ -1748,7 +1748,7 @@ pub fn detect_chips(
     continue_on_failure: bool,
     chip_filter: Option<Vec<String>>,
     noc_safe: bool,
-    callback: Option<PyObject>,
+    callback: Option<Py<PyAny>>,
 ) -> PyResult<Vec<PciChip>> {
     let chips = detect_chips_fallible(
         interfaces,
@@ -1807,8 +1807,8 @@ fn pyluwen(_py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
     Ok(())
 }
 
-/// Helper function to convert serde_json::Value to PyObject
-fn serde_json_value_to_pyobject(py: Python, value: &Value) -> PyResult<PyObject> {
+/// Helper function to convert serde_json::Value to Py<PyAny>
+fn serde_json_value_to_pyobject(py: Python, value: &Value) -> PyResult<Py<PyAny>> {
     match value {
         Value::Null => Ok(py.None()),
         Value::Bool(b) => b.into_py_any(py),
@@ -1828,7 +1828,7 @@ fn serde_json_value_to_pyobject(py: Python, value: &Value) -> PyResult<PyObject>
             // For the list we need to recursively convert each item
             let py_list = PyList::empty(py);
             for item in arr {
-                let py_item: PyObject = serde_json_value_to_pyobject(py, item)?;
+                let py_item: Py<PyAny> = serde_json_value_to_pyobject(py, item)?;
                 py_list.append(py_item)?;
             }
             py_list.into_py_any(py)
@@ -1838,7 +1838,7 @@ fn serde_json_value_to_pyobject(py: Python, value: &Value) -> PyResult<PyObject>
             let py_dict = PyDict::new(py);
             for (key, value) in obj {
                 let py_key = key.into_pyobject(py)?;
-                let py_value: PyObject = serde_json_value_to_pyobject(py, value)?;
+                let py_value: Py<PyAny> = serde_json_value_to_pyobject(py, value)?;
                 py_dict.set_item(py_key, py_value)?;
             }
             py_dict.into_py_any(py)
@@ -1846,7 +1846,7 @@ fn serde_json_value_to_pyobject(py: Python, value: &Value) -> PyResult<PyObject>
     }
 }
 
-/// Helper function to convert PyObject to serde_json::Value
+/// Helper function to convert Py<PyAny> to serde_json::Value
 fn pyobject_to_serde_json_value(_py: Python, obj: Bound<'_, PyAny>) -> PyResult<Value> {
     if obj.is_none() {
         Ok(Value::Null)

--- a/bind/pyluwen/src/lib.rs
+++ b/bind/pyluwen/src/lib.rs
@@ -1434,7 +1434,7 @@ impl PciBlackhole {
                 .0
                 .decode_boot_fs_table(tag_name)
                 .map_err(|v| PyException::new_err(v.to_string()))?;
-            let py_dict = PyDict::new(py);
+            let py_dict = PyDict::new_bound(py);
             // Convert the HashMap<String, Value> to a pydict
             for (key, value) in result {
                 let py_key: PyObject = key.into_py(py);
@@ -1452,7 +1452,7 @@ impl PciBlackhole {
         tag_name: &str,
     ) -> PyResult<()> {
         // Convert the pydict to a HashMap<String, Value>
-        let py_dict = message.as_ref(py);
+        let py_dict = message.bind(py);
         let mut result: HashMap<String, Value> = HashMap::new();
 
         for (key, value) in py_dict.iter() {
@@ -1785,7 +1785,7 @@ pub fn run_ubb_wait_for_driver_load() {
 }
 
 #[pymodule]
-fn pyluwen(_py: Python, m: &PyModule) -> PyResult<()> {
+fn pyluwen(_py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PciChip>()?;
     m.add_class::<UninitPciChip>()?;
     m.add_class::<PciWormhole>()?;
@@ -1824,7 +1824,7 @@ fn serde_json_value_to_pyobject(py: Python, value: &Value) -> PyResult<PyObject>
         Value::String(s) => Ok(s.into_py(py)),
         Value::Array(arr) => {
             // For the list we need to recursively convert each item
-            let py_list: &PyList = PyList::empty(py);
+            let py_list = PyList::empty_bound(py);
             for item in arr {
                 let py_item: PyObject = serde_json_value_to_pyobject(py, item)?;
                 py_list.append(py_item)?;
@@ -1833,7 +1833,7 @@ fn serde_json_value_to_pyobject(py: Python, value: &Value) -> PyResult<PyObject>
         }
         Value::Object(obj) => {
             // For the dict we need to recursively convert each key and value
-            let py_dict: &PyDict = PyDict::new(py);
+            let py_dict = PyDict::new_bound(py);
             for (key, value) in obj {
                 let py_key: PyObject = key.into_py(py);
                 let py_value: PyObject = serde_json_value_to_pyobject(py, value)?;
@@ -1845,7 +1845,7 @@ fn serde_json_value_to_pyobject(py: Python, value: &Value) -> PyResult<PyObject>
 }
 
 /// Helper function to convert PyObject to serde_json::Value
-fn pyobject_to_serde_json_value(_py: Python, obj: &PyAny) -> PyResult<Value> {
+fn pyobject_to_serde_json_value(_py: Python, obj: Bound<'_, PyAny>) -> PyResult<Value> {
     if obj.is_none() {
         Ok(Value::Null)
     } else if let Ok(b) = obj.extract::<bool>() {

--- a/bind/pyluwen/src/lib.rs
+++ b/bind/pyluwen/src/lib.rs
@@ -16,8 +16,8 @@ use luwen::def::Arch;
 use luwen::kmd::PossibleTlbAllocation;
 use luwen::pci::{DmaConfig, ExtendedPciDeviceWrapper};
 use pyo3::exceptions::PyException;
-use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyList};
+use pyo3::{prelude::*, IntoPyObjectExt as _};
 use serde_json::Value;
 use std::collections::HashMap;
 
@@ -1436,10 +1436,10 @@ impl PciBlackhole {
                 .0
                 .decode_boot_fs_table(tag_name)
                 .map_err(|v| PyException::new_err(v.to_string()))?;
-            let py_dict = PyDict::new_bound(py);
+            let py_dict = PyDict::new(py);
             // Convert the HashMap<String, Value> to a pydict
             for (key, value) in result {
-                let py_key: PyObject = key.into_py(py);
+                let py_key = key.into_pyobject(py)?;
                 let py_value: PyObject = serde_json_value_to_pyobject(py, &value)?;
                 py_dict.set_item(py_key, py_value)?;
             }
@@ -1811,37 +1811,37 @@ fn pyluwen(_py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
 fn serde_json_value_to_pyobject(py: Python, value: &Value) -> PyResult<PyObject> {
     match value {
         Value::Null => Ok(py.None()),
-        Value::Bool(b) => Ok(b.into_py(py)),
+        Value::Bool(b) => b.into_py_any(py),
         Value::Number(n) => {
             if let Some(value) = n.as_i64() {
-                Ok(value.into_py(py))
+                value.into_py_any(py)
             } else if let Some(value) = n.as_u64() {
-                Ok(value.into_py(py))
+                value.into_py_any(py)
             } else if let Some(value) = n.as_f64() {
-                Ok(value.into_py(py))
+                value.into_py_any(py)
             } else {
                 unimplemented!("No support for number of type {n}")
             }
         }
-        Value::String(s) => Ok(s.into_py(py)),
+        Value::String(s) => s.into_py_any(py),
         Value::Array(arr) => {
             // For the list we need to recursively convert each item
-            let py_list = PyList::empty_bound(py);
+            let py_list = PyList::empty(py);
             for item in arr {
                 let py_item: PyObject = serde_json_value_to_pyobject(py, item)?;
                 py_list.append(py_item)?;
             }
-            Ok(py_list.into_py(py))
+            py_list.into_py_any(py)
         }
         Value::Object(obj) => {
             // For the dict we need to recursively convert each key and value
-            let py_dict = PyDict::new_bound(py);
+            let py_dict = PyDict::new(py);
             for (key, value) in obj {
-                let py_key: PyObject = key.into_py(py);
+                let py_key = key.into_pyobject(py)?;
                 let py_value: PyObject = serde_json_value_to_pyobject(py, value)?;
                 py_dict.set_item(py_key, py_value)?;
             }
-            Ok(py_dict.into_py(py))
+            py_dict.into_py_any(py)
         }
     }
 }


### PR DESCRIPTION
Update pyo3 to 0.27, the latest that still supports Rust 1.75. This still supports CPython 3.7, but PyPy 3.9 and 3.10 are no longer supported.