### PR TITLE
bh-mod: expose kernel throttler parameters

### DIFF
--- a/crates/luwen-api/bh_spirom_protobufs/fw_table.proto
+++ b/crates/luwen-api/bh_spirom_protobufs/fw_table.proto
@@ -36,6 +36,7 @@ message FwTable {
     uint32 board_power_limit = 14;
     uint32 additional_board_power = 15;
     uint32 max_tdp_limit = 16;
+    uint32 kernel_throttler_stop_nops_freq = 17;
   }
 
   message FeatureEnable {
@@ -48,6 +49,7 @@ message FwTable {
     bool harvesting_en = 7;
     bool fan_ctrl_en = 8;
     bool doppler_en = 9;
+    bool kernel_throttler_at_floor_en = 10;
   }
 
   message FanTable{

--- a/crates/luwen-api/bh_spirom_protobufs/fw_table_override.proto
+++ b/crates/luwen-api/bh_spirom_protobufs/fw_table_override.proto
@@ -19,14 +19,23 @@ message FwTableOverride {
    * (FwTable field 1) is deliberately reserved here so tt-mod cannot forge
    * a bundle version.
    */
-  reserved 1, 3, 4, 5, 6, 7, 8, 9, 10;
+  reserved 1, 4, 5, 6, 7, 8, 9, 10;
 
   optional ChipLimits chip_limits = 2;
+  optional FeatureEnable feature_enable = 3;
 
   message ChipLimits {
 
     reserved 1, 2, 3, 4, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16;
 
     optional uint32 tdp_limit = 5;
+    optional uint32 kernel_throttler_stop_nops_freq = 17;
+  }
+
+  message FeatureEnable {
+
+    reserved 1, 2, 3, 4, 5, 6, 7, 8, 9;
+
+    optional bool kernel_throttler_at_floor_en = 10;
   }
 }


### PR DESCRIPTION
Expose kernel throttler parameters kernel_throttler_at_floor_en and kernel_throttler_stop_nops_freq in accordance to firmware change.

Testing done in this firmware PR (still under review): https://github.com/tenstorrent/tt-system-firmware/pull/1302

resolves: SYS-4684