### PR TITLE
crates/luwen-api/bh_spirom_protobufs:

### DIFF
--- a/crates/luwen-api/bh_spirom_protobufs/fw_table.proto
+++ b/crates/luwen-api/bh_spirom_protobufs/fw_table.proto
@@ -62,6 +62,7 @@ message FwTable {
   message DramTable {
     uint32 dram_mask = 1;
     bool dram_mask_en = 2;
+    uint32 soft_harvest_dram_mask = 3;
   }
 
   message ChipHarvestingTable {

--- a/crates/luwen-api/bh_spirom_protobufs/fw_table_override.proto
+++ b/crates/luwen-api/bh_spirom_protobufs/fw_table_override.proto
@@ -19,10 +19,12 @@ message FwTableOverride {
    * (FwTable field 1) is deliberately reserved here so tt-mod cannot forge
    * a bundle version.
    */
-  reserved 1, 4, 5, 6, 7, 8, 9, 10;
+  reserved 1, 4, 6, 7, 8, 9;
 
   optional ChipLimits chip_limits = 2;
   optional FeatureEnable feature_enable = 3;
+  optional DramTable dram_table = 5;
+  optional ProductSpecHarvesting product_spec_harvesting = 10;
 
   message ChipLimits {
 
@@ -37,5 +39,19 @@ message FwTableOverride {
     reserved 1, 2, 3, 4, 5, 6, 7, 8, 9;
 
     optional bool kernel_throttler_at_floor_en = 10;
+  }
+
+  message DramTable {
+
+    reserved 1, 2;
+
+    optional uint32 soft_harvest_dram_mask = 3;
+  }
+
+  message ProductSpecHarvesting {
+
+    reserved 2, 3;
+    
+    optional uint32 dram_disable_count = 1;
   }
 }


### PR DESCRIPTION
Added optional protobuf message soft_harvest_dram_mask in dram_table and dram_disable_count in ProductSpecHarvesting for bh_mod modification access