### PR TITLE
feat(bh-mod): allow overriding any FwTable field

### DIFF
--- a/apps/bh-mod/README.md
+++ b/apps/bh-mod/README.md
@@ -84,10 +84,11 @@ the active bank tears.
 leaving the active one intact as the rollback target. The new bank then
 becomes active on the next boot.
 
-The set of modifiable fields is defined by `fw_table_override.proto` —
-only fields explicitly exposed there can be set via `bh-mod`. Adding a
-new field requires editing the proto, the firmware's per-field merge
-list, and re-flashing.
+`bh-mod` does not gate which fields you may set: `fw_table_override.proto`
+mirrors the full `FwTable`, so any field in the table can be written to
+the override banks. The firmware decides which overrides it actually
+honours via its per-field merge in `tt_bh_fwtable_apply_ccfgovr`; a field
+the firmware does not merge is written but simply ignored at boot.
 
 ## Examples
 
@@ -111,8 +112,7 @@ bh-mod -d /dev/tenstorrent/0 get -t read-only
 bh-mod set -n chip_limits.asic_fmax=1350
 bh-mod set chip_limits.asic_fmax=1350
 
-# Stack a second override; both apply on next boot (when more fields
-# are exposed in fw_table_override.proto)
+# Stack a second override; both apply on next boot
 bh-mod set chip_limits.tdp_limit=160
 
 # Remove one override (cmfwcfg value re-emerges)
@@ -140,11 +140,6 @@ If every chip agrees, the columns collapse to a single `Value` column.
 
 ## Known limitations
 
-- **Only fields in `fw_table_override.proto` are modifiable.** Setting
-  any other field (including `fw_bundle_version`, anything in
-  `feature_enable`, etc.) is rejected at the CLI level. The override
-  surface area is intentionally narrow and grows only by deliberate
-  edits to the proto.
 - **Override body size is capped at 512 bytes** (firmware decode limit).
   A handful of fields fits comfortably; setting nearly every exposed
   field will eventually hit the cap.

--- a/apps/bh-mod/src/table.rs
+++ b/apps/bh-mod/src/table.rs
@@ -638,9 +638,8 @@ impl<'a> Set<'a> {
                 let (path, raw) = spec
                     .split_once('=')
                     .with_context(|| format!("invalid spec {spec:?}: expected field=value"))?;
-                // Look up the field's type from cmfwcfg (the FwTable schema
-                // covers a superset of FwTableOverride and uses the same
-                // types for matching fields, so it's a safe type source).
+                // Look up the field's type from cmfwcfg so we parse the raw
+                // value into the right JSON type.
                 let mut typed = get_value(&cmfwcfg, path)
                     .with_context(|| format!("unknown field path: {path}"))?
                     .clone();
@@ -649,8 +648,9 @@ impl<'a> Set<'a> {
                 insert_at_path(&mut new_map, path, typed);
                 paths.push(path);
             }
-            // Round-trip through FwTableOverride: any path not in the
-            // override proto is silently dropped by serde.
+            // Sanity round-trip through FwTableOverride. It mirrors the full
+            // FwTable, so every real field survives; this only catches an
+            // internal proto/schema mismatch, not a deliberate gate.
             let round_tripped = override_round_trip(&new_map);
             for path in &paths {
                 anyhow::ensure!(
@@ -904,9 +904,9 @@ fn remove_in_object(obj: &mut serde_json::Map<String, Value>, path: &str) {
     }
 }
 
-/// Serialize a `HashMap` through `FwTableOverride` and back. Fields not in
-/// the override schema get silently dropped by serde, so this is the
-/// allow-list filter used by `Set::run` to reject unsupported paths.
+/// Serialize a `HashMap` through `FwTableOverride` and back. The override
+/// proto mirrors the full `FwTable`, so this preserves every real field; it
+/// exists only as a sanity check for an internal proto/schema mismatch.
 fn override_round_trip(map: &HashMap<String, Value>) -> HashMap<String, Value> {
     let ovr: FwTableOverride = spirom_tables::from_hash_map(map.clone());
     spirom_tables::to_hash_map(ovr)

--- a/crates/luwen-api/bh_spirom_protobufs/fw_table_override.proto
+++ b/crates/luwen-api/bh_spirom_protobufs/fw_table_override.proto
@@ -5,45 +5,112 @@
  */
 
 /*
- * To expose a new field for override, remove its number from the reserved
- * list, add the matching optional line, and add a one-line merge in
- * tt_bh_fwtable_apply_ccfgovr.
+ * FwTableOverride mirrors the full FwTable layout: every field is exposed
+ * as an override. Field numbers and names match FwTable exactly so the
+ * encoded body is wire-compatible with the firmware's decoder.
+ *
+ * The override surface is deliberately NOT gated here. bh-mod can set any
+ * field in the table; the firmware decides which overrides it honours via
+ * its per-field merge in tt_bh_fwtable_apply_ccfgovr. Any field the
+ * firmware does not merge is simply ignored.
+ *
+ * All scalar fields use proto3 `optional` so that presence is explicit:
+ * only fields the user actually set are encoded onto the wire (and thus
+ * seen as "present" by the firmware), and an unset field leaves the
+ * cmfwcfg default in place.
  */
 
 syntax = "proto3";
 
 message FwTableOverride {
 
-  /*
-   * Field numbers reserved to match the FwTable layout. fw_bundle_version
-   * (FwTable field 1) is deliberately reserved here so tt-mod cannot forge
-   * a bundle version.
-   */
-  reserved 1, 4, 6, 7, 8, 9, 10;
-
-  optional ChipLimits chip_limits = 2;
-  optional FeatureEnable feature_enable = 3;
-  optional DramTable dram_table = 5;
+  optional uint32 fw_bundle_version = 1;
+  ChipLimits chip_limits = 2;
+  FeatureEnable feature_enable = 3;
+  FanTable fan_table = 4;
+  DramTable dram_table = 5;
+  ChipHarvestingTable chip_harvesting_table = 6;
+  PciPropertyTable pci0_property_table = 7;
+  PciPropertyTable pci1_property_table = 8;
+  EthPropertyTable eth_property_table = 9;
+  ProductSpecHarvesting product_spec_harvesting = 10;
 
   message ChipLimits {
-
-    reserved 1, 2, 3, 4, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16;
-
+    optional uint32 asic_fmax = 1;
+    optional uint32 vdd_max = 2;
+    optional uint32 vdd_min = 3;
+    optional int32 voltage_margin = 4;
     optional uint32 tdp_limit = 5;
+    optional uint32 tdc_limit = 6;
+    optional uint32 thm_limit = 7;
+    optional uint32 tdc_fast_limit = 8;
+    optional uint32 therm_trip_l1_limit = 9;
+    optional uint32 bus_peak_limit = 10;
+    optional int32 frequency_margin = 11;
+    optional uint32 asic_fmin = 12;
+    optional uint32 gddr_thm_limit = 13;
+    optional uint32 board_power_limit = 14;
+    optional uint32 additional_board_power = 15;
+    optional uint32 max_tdp_limit = 16;
     optional uint32 kernel_throttler_stop_nops_freq = 17;
   }
 
   message FeatureEnable {
-
-    reserved 1, 2, 3, 4, 5, 6, 7, 8, 9;
-
+    optional bool cg_en = 1;
+    optional bool noc_translation_en = 2;
+    optional bool ddr_train_en = 3;
+    optional bool aiclk_ppm_en = 4;
+    optional bool watchdog_en = 5;
+    optional bool smbus_en = 6;
+    optional bool harvesting_en = 7;
+    optional bool fan_ctrl_en = 8;
+    optional bool doppler_en = 9;
     optional bool kernel_throttler_at_floor_en = 10;
   }
 
+  message FanTable {
+    optional uint32 fan_table_point_x1 = 1;
+    optional uint32 fan_table_point_x2 = 2;
+    optional uint32 fan_table_point_y1 = 3;
+    optional uint32 fan_table_point_y2 = 4;
+  }
+
   message DramTable {
-
-    reserved 1, 2;
-
+    optional uint32 dram_mask = 1;
+    optional bool dram_mask_en = 2;
     optional uint32 soft_harvest_dram_mask = 3;
+  }
+
+  message ChipHarvestingTable {
+    optional uint32 soft_harvesting_en = 1;
+    optional uint32 soft_harvesting = 2;
+  }
+
+  message PciPropertyTable {
+    reserved 2;
+    optional uint32 max_pcie_speed = 1;
+    optional uint32 pcie_bar0_size = 3;
+    optional uint32 pcie_bar2_size = 4;
+    optional uint32 pcie_bar4_size = 5;
+    optional PcieMode pcie_mode = 6;
+    optional uint32 num_serdes = 7;
+
+    enum PcieMode {
+      DISABLED = 0;
+      EP = 1;
+      RP = 2;
+    }
+  }
+
+  message EthPropertyTable {
+    optional uint32 eth_disable_mask = 1;
+    optional bool eth_disable_mask_en = 2;
+    optional uint32 eth_speed_override = 3;
+  }
+
+  message ProductSpecHarvesting {
+    optional uint32 dram_disable_count = 1;
+    optional bool eth_disabled = 2;
+    optional uint32 tensix_col_disable_count = 3;
   }
 }


### PR DESCRIPTION
Expand fw_table_override.proto to mirror the full FwTable so bh-mod no longer gates which fields can be written to the ccfgovr override banks. Every field is exposed as proto3 `optional`, keeping presence explicit (only fields the user set are encoded) and the field numbers match FwTable so the body stays wire-compatible with the firmware decoder.

Gating now lives on the firmware side: its per-field merge in tt_bh_fwtable_apply_ccfgovr decides which overrides are honoured and ignores the rest. Update the bh-mod comments and README accordingly.

---

Tests:

Setting a unrecognized field `aiclk_fmax` does not result in the AICLK max changing after tt-smi -r