### PR TITLE
fix(blackhole): remove 100ms delay in spi_write

### DIFF
--- a/crates/luwen-api/src/chip/blackhole.rs
+++ b/crates/luwen-api/src/chip/blackhole.rs
@@ -375,8 +375,6 @@ impl Blackhole {
                 None,
             )?;
 
-            std::thread::sleep(std::time::Duration::from_millis(100));
-
             if status != 0 {
                 return Err("Failed to write to SPI".into());
             }


### PR DESCRIPTION
The WRITE_EEPROM (0x1A) message is synchronous. The FW erases, programs and waits for completion before sending the reply, and send_message already blocks on that response. No delay is needed.